### PR TITLE
fix cmd typo prompting user to update coolify

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -256,7 +256,7 @@ func CheckLatestVersionOfCli() (string, error) {
 	sort.Sort(compareVersion.Collection(versions))
 	latestVersion := versions[len(versions)-1].String()
 	if latestVersion != CliVersion {
-		fmt.Printf("There is a new version of Coolify CLI available.\nPlease update with 'coolify --update'.\n\n")
+		fmt.Printf("There is a new version of Coolify CLI available.\nPlease update with 'coolify update'.\n\n")
 	}
 	return latestVersion, nil
 


### PR DESCRIPTION
Notice the cli prompt to update the coolify-cli is outdated. First Go commit.

Please update with 'coolify --update'

is really just 'coolify update'
