### PR TITLE
Add coolify config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ You can change the default context with `coolify context use <context_name>` or 
 ### Update
 - `coolify update` - Update the CLI to the latest version
 
+### Configuration
+- `coolify config` - Show configuration file location
+
 ### Context Management
 - `coolify context list` - List all configured contexts
 - `coolify context add <context_name> <url> <token>` - Add a new context

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/coollabsio/coolify-cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// NewConfigCommand creates the config command
+func NewConfigCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "config",
+		Short: "Show configuration file location",
+		Long:  "Display the path to the Coolify CLI configuration file",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(config.Path())
+		},
+	}
+}

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/coollabsio/coolify-cli/internal/config"
+)
+
+func TestNewConfigCommand(t *testing.T) {
+	cmd := NewConfigCommand()
+
+	if cmd == nil {
+		t.Fatal("NewConfigCommand() returned nil")
+	}
+
+	if cmd.Use != "config" {
+		t.Errorf("Expected Use to be 'config', got '%s'", cmd.Use)
+	}
+
+	if cmd.Short == "" {
+		t.Error("Short description should not be empty")
+	}
+
+	if cmd.Long == "" {
+		t.Error("Long description should not be empty")
+	}
+
+	if cmd.Run == nil {
+		t.Error("Run function should not be nil")
+	}
+}
+
+func TestConfigCommand_Output(t *testing.T) {
+	// Test that the command returns the expected config path
+	expectedPath := config.Path()
+
+	// The path should not be empty
+	if expectedPath == "" {
+		t.Error("Expected config path to not be empty")
+	}
+
+	// The path should end with config.json
+	if !strings.HasSuffix(expectedPath, "config.json") {
+		t.Errorf("Expected path to end with 'config.json', got '%s'", expectedPath)
+	}
+
+	// The path should contain the coolify directory
+	if !strings.Contains(expectedPath, "coolify") {
+		t.Errorf("Expected path to contain 'coolify', got '%s'", expectedPath)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/coollabsio/coolify-cli/cmd/application"
 	"github.com/coollabsio/coolify-cli/cmd/completion"
+	configcmd "github.com/coollabsio/coolify-cli/cmd/config"
 	"github.com/coollabsio/coolify-cli/cmd/context"
 	"github.com/coollabsio/coolify-cli/cmd/database"
 	"github.com/coollabsio/coolify-cli/cmd/deployment"
@@ -86,8 +87,9 @@ func init() {
 
 	// Register all subcommands
 	rootCmd.AddCommand(application.NewAppCommand())
-	rootCmd.AddCommand(context.NewContextCommand())
 	rootCmd.AddCommand(completion.NewCompletionsCommand())
+	rootCmd.AddCommand(configcmd.NewConfigCommand())
+	rootCmd.AddCommand(context.NewContextCommand())
 	rootCmd.AddCommand(database.NewDatabaseCommand())
 	rootCmd.AddCommand(deployment.NewDeploymentCommand())
 	rootCmd.AddCommand(github.NewGitHubCommand())

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -556,7 +556,7 @@ func TestPath(t *testing.T) {
 		// Windows path should contain either AppData or backslashes
 		assert.True(t,
 			filepath.Separator == '\\' &&
-			(os.Getenv("APPDATA") != "" || filepath.IsAbs(path)),
+				(os.Getenv("APPDATA") != "" || filepath.IsAbs(path)),
 			"Windows path should be valid",
 		)
 	}

--- a/internal/models/application.go
+++ b/internal/models/application.go
@@ -26,20 +26,20 @@ type ApplicationListItem struct {
 // ApplicationUpdateRequest represents the request to update an application
 // All fields are optional - only provided fields will be updated
 type ApplicationUpdateRequest struct {
-	Name               *string `json:"name,omitempty"`
-	Description        *string `json:"description,omitempty"`
-	GitBranch          *string `json:"git_branch,omitempty"`
-	GitRepository      *string `json:"git_repository,omitempty"`
-	GitCommitSHA       *string `json:"git_commit_sha,omitempty"`
-	Domains            *string `json:"domains,omitempty"`
-	BuildCommand       *string `json:"build_command,omitempty"`
-	StartCommand       *string `json:"start_command,omitempty"`
-	InstallCommand     *string `json:"install_command,omitempty"`
-	BaseDirectory      *string `json:"base_directory,omitempty"`
-	PublishDirectory   *string `json:"publish_directory,omitempty"`
-	BuildPack          *string `json:"build_pack,omitempty"`
-	PortsExposes       *string `json:"ports_exposes,omitempty"`
-	PortsMappings      *string `json:"ports_mappings,omitempty"`
+	Name             *string `json:"name,omitempty"`
+	Description      *string `json:"description,omitempty"`
+	GitBranch        *string `json:"git_branch,omitempty"`
+	GitRepository    *string `json:"git_repository,omitempty"`
+	GitCommitSHA     *string `json:"git_commit_sha,omitempty"`
+	Domains          *string `json:"domains,omitempty"`
+	BuildCommand     *string `json:"build_command,omitempty"`
+	StartCommand     *string `json:"start_command,omitempty"`
+	InstallCommand   *string `json:"install_command,omitempty"`
+	BaseDirectory    *string `json:"base_directory,omitempty"`
+	PublishDirectory *string `json:"publish_directory,omitempty"`
+	BuildPack        *string `json:"build_pack,omitempty"`
+	PortsExposes     *string `json:"ports_exposes,omitempty"`
+	PortsMappings    *string `json:"ports_mappings,omitempty"`
 
 	// Docker configuration
 	Dockerfile              *string `json:"dockerfile,omitempty"`
@@ -72,9 +72,9 @@ type ApplicationUpdateRequest struct {
 	LimitsMemorySwappiness  *int    `json:"limits_memory_swappiness,omitempty"`
 
 	// Deployment hooks
-	PreDeploymentCommand          *string `json:"pre_deployment_command,omitempty"`
-	PreDeploymentCommandContainer *string `json:"pre_deployment_command_container,omitempty"`
-	PostDeploymentCommand         *string `json:"post_deployment_command,omitempty"`
+	PreDeploymentCommand           *string `json:"pre_deployment_command,omitempty"`
+	PreDeploymentCommandContainer  *string `json:"pre_deployment_command_container,omitempty"`
+	PostDeploymentCommand          *string `json:"post_deployment_command,omitempty"`
 	PostDeploymentCommandContainer *string `json:"post_deployment_command_container,omitempty"`
 
 	// Misc
@@ -112,21 +112,21 @@ type EnvironmentVariable struct {
 
 // EnvironmentVariableCreateRequest represents the request to create an environment variable
 type EnvironmentVariableCreateRequest struct {
-	Key           string `json:"key"`
-	Value         string `json:"value"`
-	IsBuildTime   *bool  `json:"is_build_time,omitempty"`
-	IsPreview     *bool  `json:"is_preview,omitempty"`
-	IsLiteral     *bool  `json:"is_literal,omitempty"`
-	IsMultiline   *bool  `json:"is_multiline,omitempty"`
+	Key         string `json:"key"`
+	Value       string `json:"value"`
+	IsBuildTime *bool  `json:"is_build_time,omitempty"`
+	IsPreview   *bool  `json:"is_preview,omitempty"`
+	IsLiteral   *bool  `json:"is_literal,omitempty"`
+	IsMultiline *bool  `json:"is_multiline,omitempty"`
 }
 
 // EnvironmentVariableUpdateRequest represents the request to update an environment variable
 type EnvironmentVariableUpdateRequest struct {
-	UUID          string  `json:"uuid"`
-	Key           *string `json:"key,omitempty"`
-	Value         *string `json:"value,omitempty"`
-	IsBuildTime   *bool   `json:"is_build_time,omitempty"`
-	IsPreview     *bool   `json:"is_preview,omitempty"`
-	IsLiteral     *bool   `json:"is_literal,omitempty"`
-	IsMultiline   *bool   `json:"is_multiline,omitempty"`
+	UUID        string  `json:"uuid"`
+	Key         *string `json:"key,omitempty"`
+	Value       *string `json:"value,omitempty"`
+	IsBuildTime *bool   `json:"is_build_time,omitempty"`
+	IsPreview   *bool   `json:"is_preview,omitempty"`
+	IsLiteral   *bool   `json:"is_literal,omitempty"`
+	IsMultiline *bool   `json:"is_multiline,omitempty"`
 }

--- a/internal/models/common.go
+++ b/internal/models/common.go
@@ -13,7 +13,7 @@ type UUID struct {
 }
 
 // Timestamps for created/updated times
-type Timestamps struct{
+type Timestamps struct {
 	CreatedAt string `json:"-" table:"-"`
 	UpdatedAt string `json:"-" table:"-"`
 }

--- a/internal/models/database.go
+++ b/internal/models/database.go
@@ -166,28 +166,28 @@ type DatabaseLifecycleResponse struct {
 
 // DatabaseBackup represents a scheduled database backup configuration
 type DatabaseBackup struct {
-	ID                                        int     `json:"-" table:"-"`
-	UUID                                      string  `json:"uuid"`
-	Description                               *string `json:"description,omitempty"`
-	Enabled                                   *bool   `json:"enabled,omitempty"`
-	Frequency                                 *string `json:"frequency,omitempty"`
-	SaveS3                                    *bool   `json:"save_s3,omitempty"`
-	S3StorageID                               *int    `json:"-" table:"-"`
-	DatabasesToBackup                         *string `json:"databases_to_backup,omitempty"`
-	DumpAll                                   *bool   `json:"dump_all,omitempty"`
-	DatabaseBackupRetentionAmountLocally      *int    `json:"database_backup_retention_amount_locally,omitempty"`
-	DatabaseBackupRetentionDaysLocally        *int    `json:"database_backup_retention_days_locally,omitempty"`
-	DatabaseBackupRetentionMaxStorageLocally  *string `json:"database_backup_retention_max_storage_locally,omitempty"`
-	DatabaseBackupRetentionAmountS3           *int    `json:"database_backup_retention_amount_s3,omitempty"`
-	DatabaseBackupRetentionDaysS3             *int    `json:"database_backup_retention_days_s3,omitempty"`
-	DatabaseBackupRetentionMaxStorageS3       *string `json:"database_backup_retention_max_storage_s3,omitempty"`
-	DatabaseType                              *string `json:"database_type,omitempty" table:"-"`
-	DatabaseID                                *int    `json:"-" table:"-"`
-	TeamID                                    *int    `json:"-" table:"-"`
-	Timeout                                   *int    `json:"timeout,omitempty"`
-	DisableLocalBackup                        *bool   `json:"disable_local_backup,omitempty"`
-	CreatedAt                                 string  `json:"-" table:"-"`
-	UpdatedAt                                 string  `json:"-" table:"-"`
+	ID                                       int     `json:"-" table:"-"`
+	UUID                                     string  `json:"uuid"`
+	Description                              *string `json:"description,omitempty"`
+	Enabled                                  *bool   `json:"enabled,omitempty"`
+	Frequency                                *string `json:"frequency,omitempty"`
+	SaveS3                                   *bool   `json:"save_s3,omitempty"`
+	S3StorageID                              *int    `json:"-" table:"-"`
+	DatabasesToBackup                        *string `json:"databases_to_backup,omitempty"`
+	DumpAll                                  *bool   `json:"dump_all,omitempty"`
+	DatabaseBackupRetentionAmountLocally     *int    `json:"database_backup_retention_amount_locally,omitempty"`
+	DatabaseBackupRetentionDaysLocally       *int    `json:"database_backup_retention_days_locally,omitempty"`
+	DatabaseBackupRetentionMaxStorageLocally *string `json:"database_backup_retention_max_storage_locally,omitempty"`
+	DatabaseBackupRetentionAmountS3          *int    `json:"database_backup_retention_amount_s3,omitempty"`
+	DatabaseBackupRetentionDaysS3            *int    `json:"database_backup_retention_days_s3,omitempty"`
+	DatabaseBackupRetentionMaxStorageS3      *string `json:"database_backup_retention_max_storage_s3,omitempty"`
+	DatabaseType                             *string `json:"database_type,omitempty" table:"-"`
+	DatabaseID                               *int    `json:"-" table:"-"`
+	TeamID                                   *int    `json:"-" table:"-"`
+	Timeout                                  *int    `json:"timeout,omitempty"`
+	DisableLocalBackup                       *bool   `json:"disable_local_backup,omitempty"`
+	CreatedAt                                string  `json:"-" table:"-"`
+	UpdatedAt                                string  `json:"-" table:"-"`
 }
 
 // DatabaseBackupCreateRequest represents the request to create a backup configuration

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -246,8 +246,8 @@ func TestTableFormatter_NilPointer(t *testing.T) {
 
 func TestTableFormatter_SliceField(t *testing.T) {
 	type TestStruct struct {
-		Name  string   `json:"name"`
-		Tags  []string `json:"tags"`
+		Name string   `json:"name"`
+		Tags []string `json:"tags"`
 	}
 
 	data := []TestStruct{

--- a/internal/service/database_test.go
+++ b/internal/service/database_test.go
@@ -280,15 +280,15 @@ func TestDatabaseService_Update(t *testing.T) {
 
 func TestDatabaseService_Delete(t *testing.T) {
 	tests := []struct {
-		name                       string
-		uuid                       string
-		deleteConfigurations       bool
-		deleteVolumes              bool
-		dockerCleanup              bool
-		deleteConnectedNetworks    bool
-		statusCode                 int
-		wantErr                    bool
-		expectedQueryString        string
+		name                    string
+		uuid                    string
+		deleteConfigurations    bool
+		deleteVolumes           bool
+		dockerCleanup           bool
+		deleteConnectedNetworks bool
+		statusCode              int
+		wantErr                 bool
+		expectedQueryString     string
 	}{
 		{
 			name:                    "successful delete with all cleanup",

--- a/internal/service/deployment_test.go
+++ b/internal/service/deployment_test.go
@@ -14,11 +14,11 @@ import (
 
 func TestDeploymentService_Deploy(t *testing.T) {
 	tests := []struct {
-		name          string
-		uuid          string
-		force         bool
-		expectedPath  string
-		response      DeployResponse
+		name         string
+		uuid         string
+		force        bool
+		expectedPath string
+		response     DeployResponse
 	}{
 		{
 			name:         "deploy without force",

--- a/internal/version/checker.go
+++ b/internal/version/checker.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CliVersion is the CLI version
-const CliVersion = "1.0.1"
+const CliVersion = "1.0.2"
 
 // CheckInterval for version checking
 const CheckInterval = 10 * time.Minute


### PR DESCRIPTION
## Background
Users need a way to easily find the location of their Coolify CLI configuration file.

## Changes
- **`cmd/config/config.go`**: Introduced a new `config` command. This command's `Run` function prints the output of `internal/config.Path()`, which dynamically determines the configuration file path based on the operating system.
- **`cmd/config/config_test.go`**: Added unit tests for the new `config` command, ensuring its `Use`, `Short`, `Long` fields are set correctly and that the `Run` function is not nil. It also verifies that the output of `config.Path()` is a valid path ending in `config.json` and containing `coolify`.
- **`cmd/root.go`**: Registered the new `configcmd.NewConfigCommand()` with the root command, making it available in the CLI.
- **`README.md`**: Added a new "Configuration" section describing the `coolify config` command and its purpose.

## Testing
- [ ] Run `coolify config` on Linux/macOS and verify the output path (e.g., `~/.config/coolify/config.json`).
- [ ] Run `coolify config` on Windows and verify the output path (e.g., `%APPDATA%\coolify\config.json`).
- [ ] Verify that the `README.md` is updated with the new command information.
