### PR TITLE
Add context verify command

### DIFF
--- a/cmd/context/context.go
+++ b/cmd/context/context.go
@@ -22,6 +22,7 @@ func NewContextCommand() *cobra.Command {
 	cmd.AddCommand(NewSetTokenCommand())
 	cmd.AddCommand(NewSetDefaultCommand())
 	cmd.AddCommand(NewVersionCommand())
+	cmd.AddCommand(NewVerifyCommand())
 
 	return cmd
 }

--- a/cmd/context/verify.go
+++ b/cmd/context/verify.go
@@ -1,0 +1,41 @@
+package context
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/coollabsio/coolify-cli/internal/cli"
+	"github.com/spf13/cobra"
+)
+
+// NewVerifyCommand creates the verify command for contexts
+func NewVerifyCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "verify",
+		Short: "Verify current context connection and authentication",
+		Long: `Verify that the current context is properly configured by testing the connection
+to the Coolify instance and validating the API token.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			// Get API client - this will use the current default context
+			client, err := cli.GetAPIClient(cmd)
+			if err != nil {
+				return fmt.Errorf("failed to get API client: %w", err)
+			}
+
+			// Try to get version - this verifies both connection and authentication
+			version, err := client.GetVersion(ctx)
+			if err != nil {
+				return fmt.Errorf("verification failed: %w", err)
+			}
+
+			// If we got here, connection and authentication are working
+			fmt.Printf("✓ Connection successful\n")
+			fmt.Printf("✓ Authentication valid\n")
+			fmt.Printf("✓ Coolify version: %s\n", version)
+
+			return nil
+		},
+	}
+}

--- a/cmd/context/verify_test.go
+++ b/cmd/context/verify_test.go
@@ -1,0 +1,105 @@
+package context
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/coollabsio/coolify-cli/internal/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerifyCommand_APIIntegration tests the verify logic using the API client directly
+// This tests the core functionality that the verify command relies on
+func TestVerifyCommand_APIIntegration(t *testing.T) {
+	t.Run("successful verification", func(t *testing.T) {
+		// Create a test HTTP server that responds to /api/v1/version
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/v1/version", r.URL.Path)
+			assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("4.0.0-beta.383"))
+		}))
+		defer server.Close()
+
+		// Create API client and verify connection
+		client := api.NewClient(server.URL, "test-token")
+		version, err := client.GetVersion(context.Background())
+
+		// Verify results
+		require.NoError(t, err)
+		assert.Equal(t, "4.0.0-beta.383", version)
+	})
+
+	t.Run("unauthorized - invalid token", func(t *testing.T) {
+		// Create a test HTTP server that returns 401
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]string{
+				"message": "Invalid token",
+			})
+		}))
+		defer server.Close()
+
+		// Create API client with invalid token
+		client := api.NewClient(server.URL, "invalid-token")
+		_, err := client.GetVersion(context.Background())
+
+		// Verify error
+		require.Error(t, err)
+		assert.True(t, api.IsUnauthorized(err))
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		// Create a test HTTP server that returns 500
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{
+				"error": "Internal server error",
+			})
+		}))
+		defer server.Close()
+
+		// Create API client
+		client := api.NewClient(server.URL, "test-token", api.WithRetries(0))
+		_, err := client.GetVersion(context.Background())
+
+		// Verify error
+		require.Error(t, err)
+		var apiErr *api.Error
+		require.ErrorAs(t, err, &apiErr)
+		assert.Equal(t, 500, apiErr.StatusCode)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		// Create a test HTTP server that returns 404
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]string{
+				"message": "Endpoint not found",
+			})
+		}))
+		defer server.Close()
+
+		// Create API client
+		client := api.NewClient(server.URL, "test-token")
+		_, err := client.GetVersion(context.Background())
+
+		// Verify error
+		require.Error(t, err)
+		assert.True(t, api.IsNotFound(err))
+	})
+}
+
+// TestNewVerifyCommand tests that the command is properly configured
+func TestNewVerifyCommand(t *testing.T) {
+	cmd := NewVerifyCommand()
+
+	assert.Equal(t, "verify", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotEmpty(t, cmd.Long)
+	assert.NotNil(t, cmd.RunE)
+}


### PR DESCRIPTION
## Background
A command is needed to verify the current context's connection and authentication with the Coolify API.

## Changes
- Added `cmd/context/verify.go`: Implements the `verify` subcommand which calls `client.GetVersion(ctx)` to check connection and authentication.
- Added `cmd/context/verify_test.go`: Includes unit tests for the `verify` command, covering successful verification, unauthorized requests, server errors, and not found scenarios using `httptest`.
- Modified `cmd/context/context.go`: Registered the new `NewVerifyCommand()` to the main `context` command group.

## Testing
- [ ] Run `coolify context verify` with a valid token and a reachable instance.
- [ ] Run `coolify context verify` with an invalid token.
- [ ] Run `coolify context verify` against a non-existent endpoint or a down instance.
