### PR TITLE
Add minimum version checks to CLI commands

### DIFF
--- a/cmd/database/backup/create.go
+++ b/cmd/database/backup/create.go
@@ -29,6 +29,11 @@ Example: coolify database backup create abc123 --frequency "0 0 * * *" --enabled
 				return fmt.Errorf("failed to get API client: %w", err)
 			}
 
+			// Check minimum version requirement
+			if err := cli.CheckMinimumVersion(ctx, client, "4.0.0-beta.436"); err != nil {
+				return err
+			}
+
 			req := &models.DatabaseBackupCreateRequest{}
 
 			// Apply flags if provided

--- a/cmd/deployment/cancel.go
+++ b/cmd/deployment/cancel.go
@@ -26,6 +26,11 @@ func NewCancelCommand() *cobra.Command {
 				return fmt.Errorf("failed to get API client: %w", err)
 			}
 
+			// Check minimum version requirement
+			if err := cli.CheckMinimumVersion(ctx, client, "4.0.0-beta.436"); err != nil {
+				return err
+			}
+
 			force, _ := cmd.Flags().GetBool("force")
 
 			// Prompt for confirmation unless --force is used

--- a/cmd/github/list.go
+++ b/cmd/github/list.go
@@ -23,6 +23,11 @@ func NewListCommand() *cobra.Command {
 				return fmt.Errorf("failed to get API client: %w", err)
 			}
 
+			// Check minimum version requirement
+			if err := cli.CheckMinimumVersion(ctx, client, "4.0.0-beta.436"); err != nil {
+				return err
+			}
+
 			svc := service.NewGitHubAppService(client)
 			apps, err := svc.List(ctx)
 			if err != nil {

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/coollabsio/coolify-cli/internal/api"
+	compareVersion "github.com/hashicorp/go-version"
 	"github.com/spf13/cobra"
 )
 
@@ -68,4 +71,28 @@ func StringPtr(s string) *string {
 
 func BoolPtr(b bool) *bool {
 	return &b
+}
+
+// CheckMinimumVersion checks if the Coolify API version meets the minimum requirement
+func CheckMinimumVersion(ctx context.Context, client *api.Client, minimumVersion string) error {
+	currentVersionStr, err := client.GetVersion(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get Coolify version: %w", err)
+	}
+
+	currentVersion, err := compareVersion.NewVersion(currentVersionStr)
+	if err != nil {
+		return fmt.Errorf("invalid current version '%s': %w", currentVersionStr, err)
+	}
+
+	minVersion, err := compareVersion.NewVersion(minimumVersion)
+	if err != nil {
+		return fmt.Errorf("invalid minimum version '%s': %w", minimumVersion, err)
+	}
+
+	if currentVersion.LessThan(minVersion) {
+		return fmt.Errorf("this command requires Coolify version %s or higher, but the current version is %s", minimumVersion, currentVersionStr)
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Background
New commands (`database backup create`, `deployment cancel`, `github list`) require specific API endpoints available only in Coolify v4.0.0-beta.436 or later. This PR adds checks to enforce this minimum version.

## Changes
- **`internal/cli/helpers.go`**:
  - Added `CheckMinimumVersion` function.
  - This function fetches the API version, parses it using `hashicorp/go-version`, and compares it against a specified minimum version.
  - It returns an error if the current version is below the minimum.
- **`cmd/database/backup/create.go`**:
  - Integrated `cli.CheckMinimumVersion` to enforce minimum version `4.0.0-beta.436`.
- **`cmd/deployment/cancel.go`**:
  - Integrated `cli.CheckMinimumVersion` to enforce minimum version `4.0.0-beta.436`.
- **`cmd/github/list.go`**:
  - Integrated `cli.CheckMinimumVersion` to enforce minimum version `4.0.0-beta.436`.

## Testing
- [ ] Run `database backup create` with an older Coolify version. Verify error message.
- [ ] Run `deployment cancel` with an older Coolify version. Verify error message.
- [ ] Run `github list` with an older Coolify version. Verify error message.
- [ ] Run all new commands with a compatible or newer Coolify version.
