### PR TITLE
Enable parallel GoReleaser builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,3 +12,5 @@ builds:
       - arm64
     env:
       - CGO_ENABLED=0
+    # Build all platforms in parallel using all available CPU cores
+    parallelism: -1


### PR DESCRIPTION
## Background
Previously, GoReleaser builds were executed sequentially, leading to longer build times in CI.

## Changes
- Modified `.goreleaser.yml` to include `parallelism: -1` under the `builds` section. This instructs GoReleaser to utilize all available CPU cores for building binaries concurrently.

## Testing
- [ ] Verify that GoReleaser builds are now running in parallel on CI.
- [ ] Confirm that build times have been significantly reduced.
