### PR TITLE
Remove gzip file validation check

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -193,11 +193,6 @@ download_from_github() {
     error_exit "Downloaded file is empty"
   fi
 
-  # Check if file is actually a tar.gz (basic check)
-  if ! file "$TEMP_FILE" | grep -q "gzip compressed"; then
-    error_exit "Downloaded file is not a valid gzip archive"
-  fi
-
   # Create install directory if it doesn't exist (for user install)
   if [ "$USER_INSTALL" = true ] && [ ! -d "$install_dir" ]; then
     echo "Creating directory: ${install_dir}"


### PR DESCRIPTION
## Changes

Removed basic check for gzip compressed file, since tar will error if not valid type anyways. However, user may need to cleanup extra directory, so we could add a sigtrap but then adding an extra dependency may cause other issues with other terminal providers.

## Issues & Discussions

- fix #35 
