### PR TITLE
fix: leading 'v' for release filename of install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -173,7 +173,7 @@ download_from_github() {
   local name=$3
   local install_dir=$4
 
-  local filename="${name}_${release}_${OS}_${ARCH}.tar.gz"
+  local filename="${name}_${release#v}_${OS}_${ARCH}.tar.gz"
   local download_url="https://github.com/${repo}/releases/download/${release}/${filename}"
 
   echo -e "${GREEN}Downloading ${name} ${release}${NC}"


### PR DESCRIPTION
## Description
Currently, the install script fails like this:
```
Coolify CLI Installer
====================

Fetching latest release version...
Version to install: v1.0.4

Install mode: Global (requires sudo)
Install directory: /usr/local/bin

Downloading coolify-cli v1.0.4
Platform: linux/amd64
URL: https://github.com/coollabsio/coolify-cli/releases/download/v1.0.4/coolify-cli_v1.0.4_linux_amd64.tar.gz
curl: (22) The requested URL returned error: 404

Error: Failed to download from https://github.com/coollabsio/coolify-cli/releases/download/v1.0.4/coolify-cli_v1.0.4_linux_amd64.tar.gz
Please check if the version exists or try again later.
```

This happens due to how the release file name is formatted: `"${name}_${release}_${OS}_${ARCH}.tar.gz"`, where `release` contains a leading "v" (e.g. `v1.0.4`). The releases do not contain this leading "v", therefore this has been fixed by stripping it, if present: `"${name}_${release#v}_${OS}_${ARCH}.tar.gz"`

## Issues & Discussions
- fix #40
