### PR TITLE
Add runtime env flag and improve service env handling

### DIFF
--- a/cmd/application/env/create.go
+++ b/cmd/application/env/create.go
@@ -31,6 +31,7 @@ func NewCreateEnvCommand() *cobra.Command {
 			isPreview, _ := cmd.Flags().GetBool("preview")
 			isLiteral, _ := cmd.Flags().GetBool("is-literal")
 			isMultiline, _ := cmd.Flags().GetBool("is-multiline")
+			isRuntime, _ := cmd.Flags().GetBool("runtime")
 
 			if key == "" {
 				return fmt.Errorf("--key is required")
@@ -56,6 +57,9 @@ func NewCreateEnvCommand() *cobra.Command {
 			if cmd.Flags().Changed("is-multiline") {
 				req.IsMultiline = &isMultiline
 			}
+			if cmd.Flags().Changed("runtime") {
+				req.IsRuntime = &isRuntime
+			}
 
 			appSvc := service.NewApplicationService(client)
 			env, err := appSvc.CreateEnv(ctx, appUUID, req)
@@ -71,9 +75,10 @@ func NewCreateEnvCommand() *cobra.Command {
 
 	cmd.Flags().String("key", "", "Environment variable key (required)")
 	cmd.Flags().String("value", "", "Environment variable value (required)")
-	cmd.Flags().Bool("build-time", false, "Available at build time")
+	cmd.Flags().Bool("build-time", true, "Available at build time (default: true)")
 	cmd.Flags().Bool("preview", false, "Available in preview deployments")
 	cmd.Flags().Bool("is-literal", false, "Treat value as literal (don't interpolate variables)")
 	cmd.Flags().Bool("is-multiline", false, "Value is multiline")
+	cmd.Flags().Bool("runtime", true, "Available at runtime (default: true)")
 	return cmd
 }

--- a/cmd/application/env/get.go
+++ b/cmd/application/env/get.go
@@ -11,10 +11,10 @@ import (
 )
 
 func NewGetEnvCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "get <app_uuid> <env_uuid_or_key>",
 		Short: "Get environment variable details",
-		Long:  `Get detailed information about a specific environment variable by UUID or key name.`,
+		Long:  `Get detailed information about a specific environment variable by UUID or key name. By default, searches non-preview environment variables. Use --preview to search preview environment variables instead.`,
 		Args:  cli.ExactArgs(2, "<app_uuid> <env_uuid_or_key>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -27,9 +27,23 @@ func NewGetEnvCommand() *cobra.Command {
 			}
 
 			appSvc := service.NewApplicationService(client)
+
+			// First try to get by the identifier directly
 			env, err := appSvc.GetEnv(ctx, appUUID, envUUIDOrKey)
 			if err != nil {
 				return fmt.Errorf("failed to get environment variable: %w", err)
+			}
+
+			// Check if the result matches the preview filter
+			showPreview, _ := cmd.Flags().GetBool("preview")
+			if env.IsPreview != showPreview {
+				// The found env doesn't match the preview filter
+				// This can happen when searching by key and there are both preview and non-preview versions
+				envType := "non-preview"
+				if showPreview {
+					envType = "preview"
+				}
+				return fmt.Errorf("environment variable '%s' not found in %s environment variables", envUUIDOrKey, envType)
 			}
 
 			showSensitive, _ := cmd.Flags().GetBool("show-sensitive")
@@ -53,4 +67,8 @@ func NewGetEnvCommand() *cobra.Command {
 			return formatter.Format(env)
 		},
 	}
+
+	cmd.Flags().Bool("preview", false, "Search preview environment variables instead of regular ones")
+
+	return cmd
 }

--- a/cmd/application/env/get.go
+++ b/cmd/application/env/get.go
@@ -14,7 +14,7 @@ func NewGetEnvCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get <app_uuid> <env_uuid_or_key>",
 		Short: "Get environment variable details",
-		Long:  `Get detailed information about a specific environment variable by UUID or key name. By default, searches non-preview environment variables. Use --preview to search preview environment variables instead.`,
+		Long:  `Get detailed information about a specific environment variable by UUID or key name.`,
 		Args:  cli.ExactArgs(2, "<app_uuid> <env_uuid_or_key>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -32,18 +32,6 @@ func NewGetEnvCommand() *cobra.Command {
 			env, err := appSvc.GetEnv(ctx, appUUID, envUUIDOrKey)
 			if err != nil {
 				return fmt.Errorf("failed to get environment variable: %w", err)
-			}
-
-			// Check if the result matches the preview filter
-			showPreview, _ := cmd.Flags().GetBool("preview")
-			if env.IsPreview != showPreview {
-				// The found env doesn't match the preview filter
-				// This can happen when searching by key and there are both preview and non-preview versions
-				envType := "non-preview"
-				if showPreview {
-					envType = "preview"
-				}
-				return fmt.Errorf("environment variable '%s' not found in %s environment variables", envUUIDOrKey, envType)
 			}
 
 			showSensitive, _ := cmd.Flags().GetBool("show-sensitive")
@@ -67,8 +55,6 @@ func NewGetEnvCommand() *cobra.Command {
 			return formatter.Format(env)
 		},
 	}
-
-	cmd.Flags().Bool("preview", false, "Search preview environment variables instead of regular ones")
 
 	return cmd
 }

--- a/cmd/application/env/list.go
+++ b/cmd/application/env/list.go
@@ -2,19 +2,21 @@ package env
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/spf13/cobra"
 
 	"github.com/coollabsio/coolify-cli/internal/cli"
+	"github.com/coollabsio/coolify-cli/internal/models"
 	"github.com/coollabsio/coolify-cli/internal/output"
 	"github.com/coollabsio/coolify-cli/internal/service"
 )
 
 func NewListEnvCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "list <app_uuid>",
 		Short: "List all environment variables for an application",
-		Long:  `List all environment variables for a specific application.`,
+		Long:  `List all environment variables for a specific application. By default, only non-preview environment variables are shown. Use --preview to show preview environment variables instead, or --all to show all variables (non-preview first, then preview).`,
 		Args:  cli.ExactArgs(1, "<uuid>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -29,6 +31,29 @@ func NewListEnvCommand() *cobra.Command {
 			envs, err := appSvc.ListEnvs(ctx, uuid)
 			if err != nil {
 				return fmt.Errorf("failed to list environment variables: %w", err)
+			}
+
+			// Filter by preview/all flags
+			showAll, _ := cmd.Flags().GetBool("all")
+			showPreview, _ := cmd.Flags().GetBool("preview")
+
+			if showAll {
+				// Sort: non-preview first, then preview
+				sort.SliceStable(envs, func(i, j int) bool {
+					if envs[i].IsPreview != envs[j].IsPreview {
+						return !envs[i].IsPreview // non-preview (false) comes before preview (true)
+					}
+					return false // maintain original order within groups
+				})
+			} else {
+				// Filter by preview flag
+				var filtered []models.EnvironmentVariable
+				for _, env := range envs {
+					if env.IsPreview == showPreview {
+						filtered = append(filtered, env)
+					}
+				}
+				envs = filtered
 			}
 
 			format, _ := cmd.Flags().GetString("format")
@@ -54,4 +79,9 @@ func NewListEnvCommand() *cobra.Command {
 			return formatter.Format(envs)
 		},
 	}
+
+	cmd.Flags().Bool("preview", false, "Show preview environment variables instead of regular ones")
+	cmd.Flags().Bool("all", false, "Show all environment variables (non-preview first, then preview)")
+
+	return cmd
 }

--- a/cmd/application/env/sync.go
+++ b/cmd/application/env/sync.go
@@ -40,6 +40,7 @@ Example: coolify app env sync abc123 --file .env.production`,
 			isBuildTime, _ := cmd.Flags().GetBool("build-time")
 			isPreview, _ := cmd.Flags().GetBool("preview")
 			isLiteral, _ := cmd.Flags().GetBool("is-literal")
+			isRuntime, _ := cmd.Flags().GetBool("runtime")
 
 			// Parse the .env file
 			envVars, err := parser.ParseEnvFile(filePath)
@@ -86,6 +87,9 @@ Example: coolify app env sync abc123 --file .env.production`,
 				}
 				if cmd.Flags().Changed("is-literal") {
 					req.IsLiteral = &isLiteral
+				}
+				if cmd.Flags().Changed("runtime") {
+					req.IsRuntime = &isRuntime
 				}
 
 				// Auto-detect multiline values
@@ -147,8 +151,9 @@ Example: coolify app env sync abc123 --file .env.production`,
 	}
 
 	syncEnvCmd.Flags().StringP("file", "f", "", "Path to .env file (required)")
-	syncEnvCmd.Flags().Bool("build-time", false, "Make all variables available at build time")
+	syncEnvCmd.Flags().Bool("build-time", true, "Make all variables available at build time (default: true)")
 	syncEnvCmd.Flags().Bool("preview", false, "Make all variables available in preview deployments")
 	syncEnvCmd.Flags().Bool("is-literal", false, "Treat all values as literal (don't interpolate variables)")
+	syncEnvCmd.Flags().Bool("runtime", true, "Make all variables available at runtime (default: true)")
 	return syncEnvCmd
 }

--- a/cmd/application/env/update.go
+++ b/cmd/application/env/update.go
@@ -54,8 +54,12 @@ func NewUpdateEnvCommand() *cobra.Command {
 				isMultiline, _ := cmd.Flags().GetBool("is-multiline")
 				req.IsMultiline = &isMultiline
 			}
+			if cmd.Flags().Changed("runtime") {
+				isRuntime, _ := cmd.Flags().GetBool("runtime")
+				req.IsRuntime = &isRuntime
+			}
 
-			if req.Key == nil && req.Value == nil && req.IsBuildTime == nil && req.IsPreview == nil && req.IsLiteral == nil && req.IsMultiline == nil {
+			if req.Key == nil && req.Value == nil && req.IsBuildTime == nil && req.IsPreview == nil && req.IsLiteral == nil && req.IsMultiline == nil && req.IsRuntime == nil {
 				return fmt.Errorf("at least one field must be provided to update")
 			}
 
@@ -72,9 +76,10 @@ func NewUpdateEnvCommand() *cobra.Command {
 
 	cmd.Flags().String("key", "", "New environment variable key")
 	cmd.Flags().String("value", "", "New environment variable value")
-	cmd.Flags().Bool("build-time", false, "Available at build time")
+	cmd.Flags().Bool("build-time", true, "Available at build time (default: true)")
 	cmd.Flags().Bool("preview", false, "Available in preview deployments")
 	cmd.Flags().Bool("is-literal", false, "Treat value as literal")
 	cmd.Flags().Bool("is-multiline", false, "Value is multiline")
+	cmd.Flags().Bool("runtime", true, "Available at runtime (default: true)")
 	return cmd
 }

--- a/cmd/service/env/create.go
+++ b/cmd/service/env/create.go
@@ -28,9 +28,9 @@ func NewCreateCommand() *cobra.Command {
 			key, _ := cmd.Flags().GetString("key")
 			value, _ := cmd.Flags().GetString("value")
 			isBuildTime, _ := cmd.Flags().GetBool("build-time")
-			isPreview, _ := cmd.Flags().GetBool("preview")
 			isLiteral, _ := cmd.Flags().GetBool("is-literal")
 			isMultiline, _ := cmd.Flags().GetBool("is-multiline")
+			isRuntime, _ := cmd.Flags().GetBool("runtime")
 
 			if key == "" {
 				return fmt.Errorf("--key is required")
@@ -39,7 +39,7 @@ func NewCreateCommand() *cobra.Command {
 				return fmt.Errorf("--value is required")
 			}
 
-			req := &models.EnvironmentVariableCreateRequest{
+			req := &models.ServiceEnvironmentVariableCreateRequest{
 				Key:   key,
 				Value: value,
 			}
@@ -48,14 +48,14 @@ func NewCreateCommand() *cobra.Command {
 			if cmd.Flags().Changed("build-time") {
 				req.IsBuildTime = &isBuildTime
 			}
-			if cmd.Flags().Changed("preview") {
-				req.IsPreview = &isPreview
-			}
 			if cmd.Flags().Changed("is-literal") {
 				req.IsLiteral = &isLiteral
 			}
 			if cmd.Flags().Changed("is-multiline") {
 				req.IsMultiline = &isMultiline
+			}
+			if cmd.Flags().Changed("runtime") {
+				req.IsRuntime = &isRuntime
 			}
 
 			serviceSvc := service.NewService(client)
@@ -71,10 +71,10 @@ func NewCreateCommand() *cobra.Command {
 
 	cmd.Flags().String("key", "", "Environment variable key (required)")
 	cmd.Flags().String("value", "", "Environment variable value (required)")
-	cmd.Flags().Bool("build-time", false, "Available at build time")
-	cmd.Flags().Bool("preview", false, "Available in preview deployments")
+	cmd.Flags().Bool("build-time", true, "Available at build time (default: true)")
 	cmd.Flags().Bool("is-literal", false, "Treat value as literal (don't interpolate variables)")
 	cmd.Flags().Bool("is-multiline", false, "Value is multiline")
+	cmd.Flags().Bool("runtime", true, "Available at runtime (default: true)")
 
 	return cmd
 }

--- a/cmd/service/env/sync.go
+++ b/cmd/service/env/sync.go
@@ -108,7 +108,7 @@ Example: coolify service env sync abc123 --file .env.production`,
 			// Perform bulk update if there are vars to update
 			if len(toUpdate) > 0 {
 				fmt.Printf("Updating %d existing variables...\n", len(toUpdate))
-				bulkReq := &service.ServiceBulkUpdateEnvsRequest{
+				bulkReq := &models.ServiceEnvBulkUpdateRequest{
 					Data: toUpdate,
 				}
 				_, err := serviceSvc.BulkUpdateEnvs(ctx, uuid, bulkReq)

--- a/cmd/service/env/sync.go
+++ b/cmd/service/env/sync.go
@@ -38,8 +38,8 @@ Example: coolify service env sync abc123 --file .env.production`,
 			}
 
 			isBuildTime, _ := cmd.Flags().GetBool("build-time")
-			isPreview, _ := cmd.Flags().GetBool("preview")
 			isLiteral, _ := cmd.Flags().GetBool("is-literal")
+			isRuntime, _ := cmd.Flags().GetBool("runtime")
 
 			// Parse the .env file
 			envVars, err := parser.ParseEnvFile(filePath)
@@ -62,17 +62,17 @@ Example: coolify service env sync abc123 --file .env.production`,
 			}
 
 			// Build a map of existing env vars by key
-			existingMap := make(map[string]models.EnvironmentVariable)
+			existingMap := make(map[string]models.ServiceEnvironmentVariable)
 			for _, env := range existingEnvs {
 				existingMap[env.Key] = env
 			}
 
 			// Separate into updates and creates
-			var toUpdate []models.EnvironmentVariableCreateRequest
-			var toCreate []models.EnvironmentVariableCreateRequest
+			var toUpdate []models.ServiceEnvironmentVariableCreateRequest
+			var toCreate []models.ServiceEnvironmentVariableCreateRequest
 
 			for _, envVar := range envVars {
-				req := models.EnvironmentVariableCreateRequest{
+				req := models.ServiceEnvironmentVariableCreateRequest{
 					Key:   envVar.Key,
 					Value: envVar.Value,
 				}
@@ -81,11 +81,11 @@ Example: coolify service env sync abc123 --file .env.production`,
 				if cmd.Flags().Changed("build-time") {
 					req.IsBuildTime = &isBuildTime
 				}
-				if cmd.Flags().Changed("preview") {
-					req.IsPreview = &isPreview
-				}
 				if cmd.Flags().Changed("is-literal") {
 					req.IsLiteral = &isLiteral
+				}
+				if cmd.Flags().Changed("runtime") {
+					req.IsRuntime = &isRuntime
 				}
 
 				// Auto-detect multiline values
@@ -108,7 +108,7 @@ Example: coolify service env sync abc123 --file .env.production`,
 			// Perform bulk update if there are vars to update
 			if len(toUpdate) > 0 {
 				fmt.Printf("Updating %d existing variables...\n", len(toUpdate))
-				bulkReq := &service.BulkUpdateEnvsRequest{
+				bulkReq := &service.ServiceBulkUpdateEnvsRequest{
 					Data: toUpdate,
 				}
 				_, err := serviceSvc.BulkUpdateEnvs(ctx, uuid, bulkReq)
@@ -147,9 +147,9 @@ Example: coolify service env sync abc123 --file .env.production`,
 	}
 
 	cmd.Flags().StringP("file", "f", "", "Path to .env file (required)")
-	cmd.Flags().Bool("build-time", false, "Make all variables available at build time")
-	cmd.Flags().Bool("preview", false, "Make all variables available in preview deployments")
+	cmd.Flags().Bool("build-time", true, "Make all variables available at build time (default: true)")
 	cmd.Flags().Bool("is-literal", false, "Treat all values as literal (don't interpolate variables)")
+	cmd.Flags().Bool("runtime", true, "Make all variables available at runtime (default: true)")
 
 	return cmd
 }

--- a/cmd/service/env/update.go
+++ b/cmd/service/env/update.go
@@ -26,7 +26,7 @@ func NewUpdateCommand() *cobra.Command {
 				return fmt.Errorf("failed to get API client: %w", err)
 			}
 
-			req := &models.EnvironmentVariableUpdateRequest{
+			req := &models.ServiceEnvironmentVariableUpdateRequest{
 				UUID: envUUID,
 			}
 
@@ -43,10 +43,6 @@ func NewUpdateCommand() *cobra.Command {
 				isBuildTime, _ := cmd.Flags().GetBool("build-time")
 				req.IsBuildTime = &isBuildTime
 			}
-			if cmd.Flags().Changed("preview") {
-				isPreview, _ := cmd.Flags().GetBool("preview")
-				req.IsPreview = &isPreview
-			}
 			if cmd.Flags().Changed("is-literal") {
 				isLiteral, _ := cmd.Flags().GetBool("is-literal")
 				req.IsLiteral = &isLiteral
@@ -55,10 +51,14 @@ func NewUpdateCommand() *cobra.Command {
 				isMultiline, _ := cmd.Flags().GetBool("is-multiline")
 				req.IsMultiline = &isMultiline
 			}
+			if cmd.Flags().Changed("runtime") {
+				isRuntime, _ := cmd.Flags().GetBool("runtime")
+				req.IsRuntime = &isRuntime
+			}
 
 			// Check if at least one field is being updated
-			if req.Key == nil && req.Value == nil && req.IsBuildTime == nil && req.IsPreview == nil && req.IsLiteral == nil && req.IsMultiline == nil {
-				return fmt.Errorf("at least one field must be provided to update (--key, --value, --build-time, --preview, --is-literal, or --is-multiline)")
+			if req.Key == nil && req.Value == nil && req.IsBuildTime == nil && req.IsLiteral == nil && req.IsMultiline == nil && req.IsRuntime == nil {
+				return fmt.Errorf("at least one field must be provided to update (--key, --value, --build-time, --is-literal, --is-multiline, or --runtime)")
 			}
 
 			serviceSvc := service.NewService(client)
@@ -74,10 +74,10 @@ func NewUpdateCommand() *cobra.Command {
 
 	cmd.Flags().String("key", "", "New environment variable key")
 	cmd.Flags().String("value", "", "New environment variable value")
-	cmd.Flags().Bool("build-time", false, "Available at build time")
-	cmd.Flags().Bool("preview", false, "Available in preview deployments")
+	cmd.Flags().Bool("build-time", true, "Available at build time (default: true)")
 	cmd.Flags().Bool("is-literal", false, "Treat value as literal (don't interpolate variables)")
 	cmd.Flags().Bool("is-multiline", false, "Value is multiline")
+	cmd.Flags().Bool("runtime", true, "Available at runtime (default: true)")
 
 	return cmd
 }

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -1,6 +1,10 @@
 package service
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/coollabsio/coolify-cli/cmd/service/env"
+)
 
 // NewServiceCommand creates the service parent command with all subcommands
 func NewServiceCommand() *cobra.Command {
@@ -19,15 +23,18 @@ func NewServiceCommand() *cobra.Command {
 	cmd.AddCommand(NewRestartCommand())
 	cmd.AddCommand(NewDeleteCommand())
 
-	// Add env subcommand (placeholder for now)
-	// TODO: Implement env commands
-	// envCmd := &cobra.Command{
-	// 	Use:     "env",
-	// 	Short:   "Manage service environment variables",
-	// }
-	// envCmd.AddCommand(env.NewListCommand())
-	// ... more env commands
-	// cmd.AddCommand(envCmd)
+	// Add env subcommand
+	envCmd := &cobra.Command{
+		Use:   "env",
+		Short: "Manage service environment variables",
+	}
+	envCmd.AddCommand(env.NewListCommand())
+	envCmd.AddCommand(env.NewGetCommand())
+	envCmd.AddCommand(env.NewCreateCommand())
+	envCmd.AddCommand(env.NewUpdateCommand())
+	envCmd.AddCommand(env.NewDeleteCommand())
+	envCmd.AddCommand(env.NewSyncCommand())
+	cmd.AddCommand(envCmd)
 
 	return cmd
 }

--- a/internal/models/application.go
+++ b/internal/models/application.go
@@ -120,6 +120,7 @@ type EnvironmentVariableCreateRequest struct {
 	IsPreview   *bool  `json:"is_preview,omitempty"`
 	IsLiteral   *bool  `json:"is_literal,omitempty"`
 	IsMultiline *bool  `json:"is_multiline,omitempty"`
+	IsRuntime   *bool  `json:"is_runtime,omitempty"`
 }
 
 // EnvironmentVariableUpdateRequest represents the request to update an environment variable
@@ -131,4 +132,5 @@ type EnvironmentVariableUpdateRequest struct {
 	IsPreview   *bool   `json:"is_preview,omitempty"`
 	IsLiteral   *bool   `json:"is_literal,omitempty"`
 	IsMultiline *bool   `json:"is_multiline,omitempty"`
+	IsRuntime   *bool   `json:"is_runtime,omitempty"`
 }

--- a/internal/models/service.go
+++ b/internal/models/service.go
@@ -107,3 +107,13 @@ type ServiceEnvironmentVariableUpdateRequest struct {
 	IsMultiline *bool   `json:"is_multiline,omitempty"`
 	IsRuntime   *bool   `json:"is_runtime,omitempty"`
 }
+
+// ServiceEnvBulkUpdateRequest represents the request to bulk update service environment variables
+type ServiceEnvBulkUpdateRequest struct {
+	Data []ServiceEnvironmentVariableCreateRequest `json:"data"`
+}
+
+// ServiceEnvBulkUpdateResponse represents the response from service bulk update
+type ServiceEnvBulkUpdateResponse struct {
+	Message string `json:"message,omitempty"`
+}

--- a/internal/models/service.go
+++ b/internal/models/service.go
@@ -68,3 +68,42 @@ type ServiceUpdateRequest struct {
 type ServiceLifecycleResponse struct {
 	Message string `json:"message"`
 }
+
+// ServiceEnvironmentVariable represents an environment variable for a service
+// Services don't have preview deployments, so IsPreview is excluded from output
+type ServiceEnvironmentVariable struct {
+	ID             int     `json:"-" table:"-"`
+	UUID           string  `json:"uuid"`
+	Key            string  `json:"key"`
+	Value          string  `json:"value" sensitive:"true"`
+	IsBuildTime    bool    `json:"is_buildtime"`
+	IsLiteralValue bool    `json:"is_literal"`
+	IsShownOnce    bool    `json:"is_shown_once"`
+	IsRuntime      bool    `json:"is_runtime"`
+	IsShared       bool    `json:"is_shared"`
+	RealValue      *string `json:"real_value,omitempty" sensitive:"true"`
+	ServiceID      *int    `json:"-" table:"-"`
+	CreatedAt      string  `json:"-" table:"-"`
+	UpdatedAt      string  `json:"-" table:"-"`
+}
+
+// ServiceEnvironmentVariableCreateRequest represents the request to create a service environment variable
+type ServiceEnvironmentVariableCreateRequest struct {
+	Key         string `json:"key"`
+	Value       string `json:"value"`
+	IsBuildTime *bool  `json:"is_build_time,omitempty"`
+	IsLiteral   *bool  `json:"is_literal,omitempty"`
+	IsMultiline *bool  `json:"is_multiline,omitempty"`
+	IsRuntime   *bool  `json:"is_runtime,omitempty"`
+}
+
+// ServiceEnvironmentVariableUpdateRequest represents the request to update a service environment variable
+type ServiceEnvironmentVariableUpdateRequest struct {
+	UUID        string  `json:"uuid"`
+	Key         *string `json:"key,omitempty"`
+	Value       *string `json:"value,omitempty"`
+	IsBuildTime *bool   `json:"is_build_time,omitempty"`
+	IsLiteral   *bool   `json:"is_literal,omitempty"`
+	IsMultiline *bool   `json:"is_multiline,omitempty"`
+	IsRuntime   *bool   `json:"is_runtime,omitempty"`
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -156,19 +156,9 @@ func (s *Service) DeleteEnv(ctx context.Context, serviceUUID, envUUID string) er
 	return nil
 }
 
-// ServiceBulkUpdateEnvsRequest represents the request to bulk update service environment variables
-type ServiceBulkUpdateEnvsRequest struct {
-	Data []models.ServiceEnvironmentVariableCreateRequest `json:"data"`
-}
-
-// ServiceBulkUpdateEnvsResponse represents the response from service bulk update
-type ServiceBulkUpdateEnvsResponse struct {
-	Message string `json:"message,omitempty"`
-}
-
 // BulkUpdateEnvs updates multiple environment variables in a single request
-func (s *Service) BulkUpdateEnvs(ctx context.Context, serviceUUID string, req *ServiceBulkUpdateEnvsRequest) (*ServiceBulkUpdateEnvsResponse, error) {
-	var response ServiceBulkUpdateEnvsResponse
+func (s *Service) BulkUpdateEnvs(ctx context.Context, serviceUUID string, req *models.ServiceEnvBulkUpdateRequest) (*models.ServiceEnvBulkUpdateResponse, error) {
+	var response models.ServiceEnvBulkUpdateResponse
 	err := s.client.Patch(ctx, fmt.Sprintf("services/%s/envs/bulk", serviceUUID), req, &response)
 	if err != nil {
 		return nil, fmt.Errorf("failed to bulk update environment variables for service %s: %w", serviceUUID, err)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -101,8 +101,8 @@ func (s *Service) Restart(ctx context.Context, uuid string) (*models.ServiceLife
 }
 
 // ListEnvs retrieves all environment variables for a service
-func (s *Service) ListEnvs(ctx context.Context, uuid string) ([]models.EnvironmentVariable, error) {
-	var envs []models.EnvironmentVariable
+func (s *Service) ListEnvs(ctx context.Context, uuid string) ([]models.ServiceEnvironmentVariable, error) {
+	var envs []models.ServiceEnvironmentVariable
 	err := s.client.Get(ctx, fmt.Sprintf("services/%s/envs", uuid), &envs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list environment variables for service %s: %w", uuid, err)
@@ -111,7 +111,7 @@ func (s *Service) ListEnvs(ctx context.Context, uuid string) ([]models.Environme
 }
 
 // GetEnv retrieves a single environment variable by UUID or key
-func (s *Service) GetEnv(ctx context.Context, serviceUUID, envIdentifier string) (*models.EnvironmentVariable, error) {
+func (s *Service) GetEnv(ctx context.Context, serviceUUID, envIdentifier string) (*models.ServiceEnvironmentVariable, error) {
 	envs, err := s.ListEnvs(ctx, serviceUUID)
 	if err != nil {
 		return nil, err
@@ -128,8 +128,8 @@ func (s *Service) GetEnv(ctx context.Context, serviceUUID, envIdentifier string)
 }
 
 // CreateEnv creates a new environment variable for a service
-func (s *Service) CreateEnv(ctx context.Context, uuid string, req *models.EnvironmentVariableCreateRequest) (*models.EnvironmentVariable, error) {
-	var env models.EnvironmentVariable
+func (s *Service) CreateEnv(ctx context.Context, uuid string, req *models.ServiceEnvironmentVariableCreateRequest) (*models.ServiceEnvironmentVariable, error) {
+	var env models.ServiceEnvironmentVariable
 	err := s.client.Post(ctx, fmt.Sprintf("services/%s/envs", uuid), req, &env)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create environment variable for service %s: %w", uuid, err)
@@ -138,8 +138,8 @@ func (s *Service) CreateEnv(ctx context.Context, uuid string, req *models.Enviro
 }
 
 // UpdateEnv updates an environment variable for a service
-func (s *Service) UpdateEnv(ctx context.Context, serviceUUID string, req *models.EnvironmentVariableUpdateRequest) (*models.EnvironmentVariable, error) {
-	var env models.EnvironmentVariable
+func (s *Service) UpdateEnv(ctx context.Context, serviceUUID string, req *models.ServiceEnvironmentVariableUpdateRequest) (*models.ServiceEnvironmentVariable, error) {
+	var env models.ServiceEnvironmentVariable
 	err := s.client.Patch(ctx, fmt.Sprintf("services/%s/envs", serviceUUID), req, &env)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update environment variable for service %s: %w", serviceUUID, err)
@@ -156,9 +156,19 @@ func (s *Service) DeleteEnv(ctx context.Context, serviceUUID, envUUID string) er
 	return nil
 }
 
+// ServiceBulkUpdateEnvsRequest represents the request to bulk update service environment variables
+type ServiceBulkUpdateEnvsRequest struct {
+	Data []models.ServiceEnvironmentVariableCreateRequest `json:"data"`
+}
+
+// ServiceBulkUpdateEnvsResponse represents the response from service bulk update
+type ServiceBulkUpdateEnvsResponse struct {
+	Message string `json:"message,omitempty"`
+}
+
 // BulkUpdateEnvs updates multiple environment variables in a single request
-func (s *Service) BulkUpdateEnvs(ctx context.Context, serviceUUID string, req *BulkUpdateEnvsRequest) (*BulkUpdateEnvsResponse, error) {
-	var response BulkUpdateEnvsResponse
+func (s *Service) BulkUpdateEnvs(ctx context.Context, serviceUUID string, req *ServiceBulkUpdateEnvsRequest) (*ServiceBulkUpdateEnvsResponse, error) {
+	var response ServiceBulkUpdateEnvsResponse
 	err := s.client.Patch(ctx, fmt.Sprintf("services/%s/envs/bulk", serviceUUID), req, &response)
 	if err != nil {
 		return nil, fmt.Errorf("failed to bulk update environment variables for service %s: %w", serviceUUID, err)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -299,7 +299,7 @@ func TestService_CreateEnv(t *testing.T) {
 	client := api.NewClient(server.URL, "test-token")
 	svc := NewService(client)
 
-	env, err := svc.CreateEnv(context.Background(), "service-uuid-123", &models.EnvironmentVariableCreateRequest{
+	env, err := svc.CreateEnv(context.Background(), "service-uuid-123", &models.ServiceEnvironmentVariableCreateRequest{
 		Key:   "NEW_VAR",
 		Value: "new_value",
 	})
@@ -329,7 +329,7 @@ func TestService_UpdateEnv(t *testing.T) {
 	svc := NewService(client)
 
 	newKey := "UPDATED_VAR"
-	env, err := svc.UpdateEnv(context.Background(), "service-uuid-123", &models.EnvironmentVariableUpdateRequest{
+	env, err := svc.UpdateEnv(context.Background(), "service-uuid-123", &models.ServiceEnvironmentVariableUpdateRequest{
 		UUID: "env-123",
 		Key:  &newKey,
 	})

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -255,14 +255,14 @@ func TestService_ListEnvs(t *testing.T) {
 				"uuid": "env-1",
 				"key": "DATABASE_URL",
 				"value": "postgres://localhost",
-				"is_build_time": false,
+				"is_buildtime": false,
 				"is_preview": false
 			},
 			{
 				"uuid": "env-2",
 				"key": "API_KEY",
 				"value": "secret",
-				"is_build_time": true,
+				"is_buildtime": true,
 				"is_preview": false
 			}
 		]`))
@@ -290,7 +290,7 @@ func TestService_CreateEnv(t *testing.T) {
 			"uuid": "env-new",
 			"key": "NEW_VAR",
 			"value": "new_value",
-			"is_build_time": false,
+			"is_buildtime": false,
 			"is_preview": false
 		}`))
 	}))
@@ -319,7 +319,7 @@ func TestService_UpdateEnv(t *testing.T) {
 			"uuid": "env-123",
 			"key": "UPDATED_VAR",
 			"value": "updated_value",
-			"is_build_time": true,
+			"is_buildtime": true,
 			"is_preview": false
 		}`))
 	}))


### PR DESCRIPTION
## Changes

- Add `--runtime` flag to all environment variable commands for apps and services
- Change `--runtime` and `--build-time` defaults to `true`
- Remove `is_preview` field from service environment variables (not applicable to services)
- Create service-specific `ServiceEnvironmentVariable` model
- Wire up service env subcommands
- Add `--preview` filter to app env list/get commands
- Add `--all` flag to app env list to show all variables (non-preview first)

## Issues & Discussions

Improvements to CLI environment variable management and API consistency.