### PR TITLE
fix: use bulk endpoint for service env update to resolve 404

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -137,14 +137,58 @@ func (s *Service) CreateEnv(ctx context.Context, uuid string, req *models.Servic
 	return &env, nil
 }
 
-// UpdateEnv updates an environment variable for a service
+// UpdateEnv updates an environment variable for a service.
+// Uses the bulk update endpoint as the single-update endpoint
+// (PATCH /services/{uuid}/envs) returns 404 for services.
+// See: https://github.com/coollabsio/coolify-cli/issues/48
 func (s *Service) UpdateEnv(ctx context.Context, serviceUUID string, req *models.ServiceEnvironmentVariableUpdateRequest) (*models.ServiceEnvironmentVariable, error) {
-	var env models.ServiceEnvironmentVariable
-	err := s.client.Patch(ctx, fmt.Sprintf("services/%s/envs", serviceUUID), req, &env)
+	// Fetch the current env var to get existing values for fields not being updated
+	existing, err := s.GetEnv(ctx, serviceUUID, req.UUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch environment variable for update: %w", err)
+	}
+
+	// Build the bulk update entry, applying requested changes over existing values
+	entry := models.ServiceEnvironmentVariableCreateRequest{
+		Key:   existing.Key,
+		Value: existing.Value,
+	}
+	if req.Key != nil {
+		entry.Key = *req.Key
+	}
+	if req.Value != nil {
+		entry.Value = *req.Value
+	}
+	isBuildTime := existing.IsBuildTime
+	if req.IsBuildTime != nil {
+		isBuildTime = *req.IsBuildTime
+	}
+	entry.IsBuildTime = &isBuildTime
+	isLiteral := existing.IsLiteralValue
+	if req.IsLiteral != nil {
+		isLiteral = *req.IsLiteral
+	}
+	entry.IsLiteral = &isLiteral
+	isRuntime := existing.IsRuntime
+	if req.IsRuntime != nil {
+		isRuntime = *req.IsRuntime
+	}
+	entry.IsRuntime = &isRuntime
+
+	bulkReq := &models.ServiceEnvBulkUpdateRequest{
+		Data: []models.ServiceEnvironmentVariableCreateRequest{entry},
+	}
+	err = s.client.Patch(ctx, fmt.Sprintf("services/%s/envs/bulk", serviceUUID), bulkReq, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update environment variable for service %s: %w", serviceUUID, err)
 	}
-	return &env, nil
+
+	// Fetch the updated env var to return the current state
+	updated, err := s.GetEnv(ctx, serviceUUID, entry.Key)
+	if err != nil {
+		return nil, fmt.Errorf("environment variable updated but failed to fetch result: %w", err)
+	}
+	return updated, nil
 }
 
 // DeleteEnv deletes an environment variable from a service

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -310,18 +310,44 @@ func TestService_CreateEnv(t *testing.T) {
 }
 
 func TestService_UpdateEnv(t *testing.T) {
+	getCount := 0
+	requestCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/v1/services/service-uuid-123/envs", r.URL.Path)
-		assert.Equal(t, "PATCH", r.Method)
-
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{
-			"uuid": "env-123",
-			"key": "UPDATED_VAR",
-			"value": "updated_value",
-			"is_buildtime": true,
-			"is_preview": false
-		}`))
+		requestCount++
+		if r.Method == "GET" && r.URL.Path == "/api/v1/services/service-uuid-123/envs" {
+			getCount++
+			if getCount == 1 {
+				// First GET: list envs to find the one being updated
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`[{
+					"uuid": "env-123",
+					"key": "MY_VAR",
+					"value": "old_value",
+					"is_buildtime": false,
+					"is_literal": false,
+					"is_runtime": true,
+					"is_shared": false
+				}]`))
+			} else {
+				// Second GET: re-fetch after update returns updated env
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`[{
+					"uuid": "env-123",
+					"key": "UPDATED_VAR",
+					"value": "old_value",
+					"is_buildtime": false,
+					"is_literal": false,
+					"is_runtime": true,
+					"is_shared": false
+				}]`))
+			}
+		} else if r.Method == "PATCH" && r.URL.Path == "/api/v1/services/service-uuid-123/envs/bulk" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"message": "success"}`))
+		} else {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
 	}))
 	defer server.Close()
 
@@ -336,6 +362,7 @@ func TestService_UpdateEnv(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "UPDATED_VAR", env.Key)
+	assert.Equal(t, 3, requestCount)
 }
 
 func TestService_DeleteEnv(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #48 — `service env update` returns 404 because `PATCH /services/{uuid}/envs` doesn't exist for services.

## Changes

Routes single env var updates through the working bulk endpoint `PATCH /services/{uuid}/envs/bulk` instead.

The method:
1. Fetches the current env var to preserve existing values for fields not being updated
2. Applies the requested changes
3. Sends via the bulk endpoint
4. Fetches and returns the updated env var

## How to test

```bash
coolify service env list <service_uuid>
coolify service env update <service_uuid> <env_uuid> --value "new_value"
# Previously: 404 "Service not found"
# Now: updates successfully via bulk endpoint
```

## Related

Found while building [Paasman](https://github.com/aerocyberlabs/paasman), a universal CLI for self-hosted PaaS platforms.