### PR TITLE
fix(database): respect --format flag in database list and get commands

### DIFF
--- a/cmd/database/get.go
+++ b/cmd/database/get.go
@@ -32,15 +32,25 @@ func NewGetCommand() *cobra.Command {
 				return fmt.Errorf("failed to get database: %w", err)
 			}
 
+			format, _ := cmd.Flags().GetString("format")
 			showSensitive, _ := cmd.Flags().GetBool("show-sensitive")
-			formatter, err := output.NewFormatter("table", output.Options{
+
+			formatter, err := output.NewFormatter(format, output.Options{
 				ShowSensitive: showSensitive,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to create formatter: %w", err)
 			}
 
-			return formatter.Format(database)
+			if err := formatter.Format(database); err != nil {
+				return err
+			}
+
+			if !showSensitive && format == output.FormatTable {
+				fmt.Println("\nNote: Use -s to show sensitive information.")
+			}
+
+			return nil
 		},
 	}
 }

--- a/cmd/database/list.go
+++ b/cmd/database/list.go
@@ -30,12 +30,25 @@ func NewListCommand() *cobra.Command {
 				return fmt.Errorf("failed to list databases: %w", err)
 			}
 
-			formatter, err := output.NewFormatter("table", output.Options{})
+			format, _ := cmd.Flags().GetString("format")
+			showSensitive, _ := cmd.Flags().GetBool("show-sensitive")
+
+			formatter, err := output.NewFormatter(format, output.Options{
+				ShowSensitive: showSensitive,
+			})
 			if err != nil {
 				return fmt.Errorf("failed to create formatter: %w", err)
 			}
 
-			return formatter.Format(databases)
+			if err := formatter.Format(databases); err != nil {
+				return err
+			}
+
+			if !showSensitive && format == output.FormatTable {
+				fmt.Println("\nNote: Use -s to show sensitive information.")
+			}
+
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
The database list and get commands were hardcoded to use table format, ignoring the global --format flag. This prevented users from using --format=json or --format=pretty output formats.

Changes:
- cmd/database/list.go: read format flag from command
- cmd/database/get.go: read format flag from command
- Both commands now follow the same pattern as other list/get commands
