### PR TITLE
fix(service): respect --format and --show-sensitive flags in get and list commands

### DIFF
--- a/cmd/service/get.go
+++ b/cmd/service/get.go
@@ -32,7 +32,12 @@ func NewGetCommand() *cobra.Command {
 				return fmt.Errorf("failed to get service: %w", err)
 			}
 
-			formatter, err := output.NewFormatter("table", output.Options{})
+			format, _ := cmd.Flags().GetString("format")
+			showSensitive, _ := cmd.Flags().GetBool("show-sensitive")
+
+			formatter, err := output.NewFormatter(format, output.Options{
+				ShowSensitive: showSensitive,
+			})
 			if err != nil {
 				return fmt.Errorf("failed to create formatter: %w", err)
 			}

--- a/cmd/service/list.go
+++ b/cmd/service/list.go
@@ -30,7 +30,12 @@ func NewListCommand() *cobra.Command {
 				return fmt.Errorf("failed to list services: %w", err)
 			}
 
-			formatter, err := output.NewFormatter("table", output.Options{})
+			format, _ := cmd.Flags().GetString("format")
+			showSensitive, _ := cmd.Flags().GetBool("show-sensitive")
+
+			formatter, err := output.NewFormatter(format, output.Options{
+				ShowSensitive: showSensitive,
+			})
 			if err != nil {
 				return fmt.Errorf("failed to create formatter: %w", err)
 			}


### PR DESCRIPTION
## Summary

- Fixes #69: `coolify service list --format json` was always printing as table regardless of the flag
- `get` and `list` commands were hardcoding `"table"` as the formatter instead of reading the `--format` flag
- Both commands now read `--format` and `--show-sensitive` from the cobra flags and pass them to `output.NewFormatter`


---

Fixes #69