### PR TITLE
feat(app): add --service for compose app logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Commands can use `server` or `servers` interchangeably.
   - `-f, --follow` - Follow log output (like tail -f)
   - `-n, --lines <n>` - Number of log lines to retrieve (default: 100)
   - `--show-timestamps` - Include timestamps in logs
+  - `--service <name>` - Docker Compose service name (select one container in multi-service compose apps)
 - `coolify app move <uuid> --environment-uuid <uuid>` - Move an application to another environment
 - `coolify app tag list|add|remove` - Manage application tags
 - Git-backed application create variants (`public`, `github`, and `deploy-key`) and `app update` support repeatable `--compose-domain <service>=<url>[,<url>]` flags for Docker Compose routing. On update, the supplied entries replace the existing mapping.
@@ -556,6 +557,9 @@ coolify app restart <uuid>
 
 # View application logs
 coolify app logs <uuid>
+
+# View logs for one service in a Docker Compose application
+coolify app logs <uuid> --service web
 
 # Environment variables
 coolify app env list <uuid>

--- a/cmd/application/application_test.go
+++ b/cmd/application/application_test.go
@@ -28,6 +28,7 @@ func TestNewAppCommand_RegistersMoveAndTagCommands(t *testing.T) {
 
 func TestNewApplicationCommands_ExposeParityFlags(t *testing.T) {
 	assert.NotNil(t, NewLogsCommand().Flags().Lookup("show-timestamps"))
+	assert.NotNil(t, NewLogsCommand().Flags().Lookup("service"))
 	assert.NotNil(t, NewMoveCommand().Flags().Lookup("environment-uuid"))
 	assert.NotNil(t, NewUpdateCommand().Flags().Lookup("compose-domain"))
 

--- a/cmd/application/logs.go
+++ b/cmd/application/logs.go
@@ -18,8 +18,12 @@ func NewLogsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logs <uuid>",
 		Short: "Get application logs",
-		Long:  `Retrieve logs for an application. Use --follow to continuously stream new logs.`,
-		Args:  cli.ExactArgs(1, "<uuid>"),
+		Long: `Retrieve logs for an application. Use --follow to continuously stream new logs.
+
+For Docker Compose applications with multiple services, pass --service <name>
+(the compose service key, e.g. web or db) to select which container's logs to return.
+Without --service, the API returns logs from the first running container.`,
+		Args: cli.ExactArgs(1, "<uuid>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			uuid := args[0]
@@ -32,10 +36,11 @@ func NewLogsCommand() *cobra.Command {
 			lines, _ := cmd.Flags().GetInt("lines")
 			follow, _ := cmd.Flags().GetBool("follow")
 			showTimestamps, _ := cmd.Flags().GetBool("show-timestamps")
+			serviceName, _ := cmd.Flags().GetString("service")
 			appSvc := service.NewApplicationService(client)
 
 			if !follow {
-				resp, err := appSvc.Logs(ctx, uuid, lines, showTimestamps)
+				resp, err := appSvc.Logs(ctx, uuid, lines, showTimestamps, serviceName)
 				if err != nil {
 					return fmt.Errorf("failed to get logs: %w", err)
 				}
@@ -51,7 +56,7 @@ func NewLogsCommand() *cobra.Command {
 
 			lastLogs := ""
 
-			resp, err := appSvc.Logs(ctx, uuid, lines, showTimestamps)
+			resp, err := appSvc.Logs(ctx, uuid, lines, showTimestamps, serviceName)
 			if err != nil {
 				return fmt.Errorf("failed to get logs: %w", err)
 			}
@@ -64,7 +69,7 @@ func NewLogsCommand() *cobra.Command {
 					fmt.Println("\nStopping log follow...")
 					return nil
 				case <-ticker.C:
-					resp, err := appSvc.Logs(ctx, uuid, lines, showTimestamps)
+					resp, err := appSvc.Logs(ctx, uuid, lines, showTimestamps, serviceName)
 					if err != nil {
 						continue
 					}
@@ -84,5 +89,6 @@ func NewLogsCommand() *cobra.Command {
 	cmd.Flags().IntP("lines", "n", 100, "Number of log lines to retrieve")
 	cmd.Flags().BoolP("follow", "f", false, "Follow log output (like tail -f)")
 	cmd.Flags().Bool("show-timestamps", false, "Show timestamps in log output")
+	cmd.Flags().String("service", "", "Docker Compose service name (selects one container in multi-service apps)")
 	return cmd
 }

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -195,6 +195,7 @@ coolify app start <uuid>
 coolify app stop <uuid>
 coolify app restart <uuid>
 coolify app logs <uuid> --show-timestamps
+coolify app logs <uuid> --service web --follow
 coolify app move <uuid> --environment-uuid <uuid>
 coolify app tag add <uuid> production
 coolify app deployments list <app-uuid>

--- a/internal/service/application.go
+++ b/internal/service/application.go
@@ -116,8 +116,10 @@ func (s *ApplicationService) Restart(ctx context.Context, uuid string) (*models.
 	return &resp, nil
 }
 
-// Logs retrieves logs for an application
-func (s *ApplicationService) Logs(ctx context.Context, uuid string, lines int, showTimestamps bool) (*models.ApplicationLogsResponse, error) {
+// Logs retrieves logs for an application.
+// serviceName selects a docker-compose service container (API query service_name).
+// Empty serviceName keeps legacy behavior (first/only container).
+func (s *ApplicationService) Logs(ctx context.Context, uuid string, lines int, showTimestamps bool, serviceName string) (*models.ApplicationLogsResponse, error) {
 	endpoint := fmt.Sprintf("applications/%s/logs", uuid)
 	query := url.Values{}
 	if lines > 0 {
@@ -125,6 +127,9 @@ func (s *ApplicationService) Logs(ctx context.Context, uuid string, lines int, s
 	}
 	if showTimestamps {
 		query.Set("show_timestamps", strconv.FormatBool(showTimestamps))
+	}
+	if serviceName != "" {
+		query.Set("service_name", serviceName)
 	}
 	if encodedQuery := query.Encode(); encodedQuery != "" {
 		endpoint += "?" + encodedQuery

--- a/internal/service/application_test.go
+++ b/internal/service/application_test.go
@@ -630,7 +630,7 @@ func TestApplicationService_Logs(t *testing.T) {
 	client := api.NewClient(server.URL, "test-token")
 	svc := NewApplicationService(client)
 
-	result, err := svc.Logs(context.Background(), "app-uuid-123", 0, false)
+	result, err := svc.Logs(context.Background(), "app-uuid-123", 0, false, "")
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Contains(t, result.Logs, "Application started")
@@ -653,7 +653,7 @@ func TestApplicationService_Logs_WithLines(t *testing.T) {
 	client := api.NewClient(server.URL, "test-token")
 	svc := NewApplicationService(client)
 
-	result, err := svc.Logs(context.Background(), "app-uuid-123", 50, false)
+	result, err := svc.Logs(context.Background(), "app-uuid-123", 50, false, "")
 	require.NoError(t, err)
 	assert.NotNil(t, result)
 }
@@ -668,10 +668,27 @@ func TestApplicationService_Logs_WithLinesAndTimestamps(t *testing.T) {
 	defer server.Close()
 
 	client := api.NewClient(server.URL, "test-token")
-	result, err := NewApplicationService(client).Logs(context.Background(), "app-uuid-123", 25, true)
+	result, err := NewApplicationService(client).Logs(context.Background(), "app-uuid-123", 25, true, "")
 
 	require.NoError(t, err)
 	assert.Equal(t, "timestamped", result.Logs)
+}
+
+func TestApplicationService_Logs_WithServiceName(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/applications/app-uuid-123/logs", r.URL.Path)
+		assert.Equal(t, "web", r.URL.Query().Get("service_name"))
+		assert.Equal(t, "50", r.URL.Query().Get("lines"))
+		assert.Equal(t, "true", r.URL.Query().Get("show_timestamps"))
+		_ = json.NewEncoder(w).Encode(models.ApplicationLogsResponse{Logs: "web service logs"})
+	}))
+	defer server.Close()
+
+	client := api.NewClient(server.URL, "test-token")
+	result, err := NewApplicationService(client).Logs(context.Background(), "app-uuid-123", 50, true, "web")
+
+	require.NoError(t, err)
+	assert.Equal(t, "web service logs", result.Logs)
 }
 
 func TestApplicationService_Move(t *testing.T) {
@@ -710,7 +727,7 @@ func TestApplicationService_Logs_Error(t *testing.T) {
 	client := api.NewClient(server.URL, "test-token")
 	svc := NewApplicationService(client)
 
-	result, err := svc.Logs(context.Background(), "app-uuid-123", 0, false)
+	result, err := svc.Logs(context.Background(), "app-uuid-123", 0, false, "")
 	require.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to get logs for application")

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1543,7 +1543,7 @@ Description: List all applications in Coolify.
 Parameters: (None)
 
 Command: coolify app logs <uuid>
-Description: Retrieve logs for an application. Use --follow to continuously stream new logs.
+Description: Get application logs
 Parameters:
   - name: --follow (-f)
     type: boolean
@@ -1555,6 +1555,10 @@ Parameters:
     description: Number of log lines to retrieve
     required: false
     default: 100
+  - name: --service
+    type: string
+    description: Docker Compose service name (selects one container in multi-service apps)
+    required: false
   - name: --show-timestamps
     type: boolean
     description: Show timestamps in log output

--- a/llms.txt
+++ b/llms.txt
@@ -88,6 +88,7 @@ coolify app start <uuid>
 coolify app stop <uuid>
 coolify app restart <uuid>
 coolify app logs <uuid> --show-timestamps
+coolify app logs <uuid> --service web --follow
 coolify app move <uuid> --environment-uuid <uuid>
 coolify app tag add <uuid> production
 coolify app deployments list <app-uuid>


### PR DESCRIPTION
## Summary

- Add `--service <name>` to `coolify app logs` so multi-service Docker Compose apps can fetch logs for a specific service
- Pass the service name to the API as `service_name`; omit it to keep the previous first-container behavior
- Document the flag in README, command help, and examples
- Cover the new query parameter with service-layer and command flag tests

## Related

fixes #75

---

Fixes #75