### PR TITLE
feat: support repo-local config for context selection

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -202,6 +202,20 @@ func (c *Client) Get(ctx context.Context, path string, result interface{}) error
 - `config.go` - Configuration structure and methods
 - `instance.go` - Instance definition
 - `loader.go` - File I/O operations
+- `local.go` - Repo-local config discovery (`.coolify.json` / `.coolifyrc`)
+
+**Context Resolution** (in `cli.GetAPIClient`):
+1. `--context` flag
+2. Nearest repo-local `.coolify.json` / `.coolifyrc`, found by walking up from the working directory
+3. Global default instance
+
+The repo-local file only names a context that exists in the global config, so
+tokens stay out of the repository:
+```json
+{
+  "context": "production"
+}
+```
 
 **Configuration File** (`~/.config/coolify/config.json`):
 ```json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ The codebase follows Cobra's command pattern with a root command and subcommands
 - Uses Viper for configuration management
 - Config file location: `~/.config/coolify/config.json` (via xdg package)
 - Config stores multiple instances with tokens, default instance selection
+- Repo-local override: `.coolify.json` / `.coolifyrc` (see `internal/config/local.go`), discovered by walking up from the working directory. Holds only `{"context": "<name>"}` - never credentials. Context resolution in `cli.GetAPIClient` is `--context` flag > repo-local file > global default
 - Global flags available: `--token`, `--host`, `--format`, `--show-sensitive`, `--force`, `--debug`
 
 ### API Communication

--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ go run ./coolify docs llms
 
 ## Change default context
 You can change the default context with `coolify context use <context_name>` or `coolify context set-default <context_name>`
+
+## Repo-local context
+
+Drop a `.coolify.json` (or `.coolifyrc`) at the root of a repo to pin every command run inside it to one context:
+
+```json
+{
+  "context": "production"
+}
+```
+
+The CLI walks up from the working directory to find the nearest one. Resolution order:
+
+1. `--context` flag
+2. repo-local `.coolify.json` / `.coolifyrc`
+3. global default context
+
+The file only names a context that already exists in your global config — tokens stay in `~/.config/coolify/config.json` and never belong in the repo. Run with `--debug` to see which file the context came from.
+
 ## Currently Supported Commands
 
 ### Update
@@ -490,7 +509,7 @@ Commands can use `private-key`, `private-keys`, `key`, or `keys` interchangeably
 
 All commands support these global flags:
 
-- `--context <name>` - Use a specific context instead of default
+- `--context <name>` - Use a specific context instead of the repo-local or default one (see [Repo-local context](#repo-local-context))
 - `--token <token>` - Override the authentication token
 - `--format <format>` - Output format: `table` (default), `json`, or `pretty`
 - `-s, --show-sensitive` - Show sensitive information (tokens, IPs, etc.)

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -22,11 +23,22 @@ func GetAPIClient(cmd *cobra.Command) (*api.Client, error) {
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
 
+	// Precedence: --context flag > repo-local config file > global default
+	localPath := ""
+	if contextName == "" {
+		contextName, localPath, err = config.LocalContext()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	var instance *config.Instance
-	// Use context if specified, otherwise use default
 	if contextName != "" {
 		instance, err = cfg.GetInstance(contextName)
 		if err != nil {
+			if localPath != "" {
+				return nil, fmt.Errorf("context '%s' from %s not found in %s", contextName, localPath, config.Path())
+			}
 			return nil, fmt.Errorf("context '%s' not found: %w", contextName, err)
 		}
 	} else {
@@ -34,6 +46,10 @@ func GetAPIClient(cmd *cobra.Command) (*api.Client, error) {
 		if err != nil {
 			return nil, fmt.Errorf("no default instance configured: %w", err)
 		}
+	}
+
+	if debug && localPath != "" {
+		fmt.Fprintf(os.Stderr, "Using context '%s' from %s\n", contextName, localPath)
 	}
 
 	// Get FQDN from instance

--- a/internal/config/local.go
+++ b/internal/config/local.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// LocalFileNames are the repo-local config file names, checked in this order in
+// each directory while walking up from the working directory.
+var LocalFileNames = []string{".coolify.json", ".coolifyrc"}
+
+// LocalConfig is the repo-local config. It only points at a context that
+// already exists in the global config - credentials stay global, never in the
+// repo.
+type LocalConfig struct {
+	Context string `json:"context"`
+
+	// Path is the file this was read from (not serialized).
+	Path string `json:"-"`
+}
+
+// FindLocal walks up from dir looking for a repo-local config file. Returns nil
+// when none is found.
+func FindLocal(dir string) (*LocalConfig, error) {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		for _, name := range LocalFileNames {
+			path := filepath.Join(dir, name)
+			if !fileExists(path) {
+				continue
+			}
+
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read %s: %w", path, err)
+			}
+
+			var local LocalConfig
+			if err := json.Unmarshal(data, &local); err != nil {
+				return nil, fmt.Errorf("failed to parse %s: %w", path, err)
+			}
+			local.Path = path
+			return &local, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return nil, nil
+		}
+		dir = parent
+	}
+}
+
+// LocalContext returns the context name declared by the nearest repo-local
+// config file, plus the file it came from. Both are empty when there is none.
+func LocalContext() (name, path string, err error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", "", err
+	}
+
+	local, err := FindLocal(cwd)
+	if err != nil || local == nil {
+		return "", "", err
+	}
+	return local.Context, local.Path, nil
+}

--- a/internal/config/local_test.go
+++ b/internal/config/local_test.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindLocal(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "a", "b")
+	if err := os.MkdirAll(nested, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	// No file anywhere up the tree (TempDir parents have none).
+	local, err := FindLocal(nested)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if local != nil {
+		t.Fatalf("expected no local config, got %+v", local)
+	}
+
+	// Found by walking up from a nested dir.
+	rootFile := filepath.Join(root, ".coolify.json")
+	if err := os.WriteFile(rootFile, []byte(`{"context":"production"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	local, err = FindLocal(nested)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if local == nil || local.Context != "production" || local.Path != rootFile {
+		t.Fatalf("got %+v, want context=production path=%s", local, rootFile)
+	}
+
+	// Nearest file wins.
+	nestedFile := filepath.Join(nested, ".coolifyrc")
+	if err := os.WriteFile(nestedFile, []byte(`{"context":"staging"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	local, err = FindLocal(nested)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if local.Context != "staging" || local.Path != nestedFile {
+		t.Fatalf("got %+v, want context=staging path=%s", local, nestedFile)
+	}
+
+	// Malformed JSON is an error, not a silent fallback.
+	if err := os.WriteFile(nestedFile, []byte("context = production"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := FindLocal(nested); err == nil {
+		t.Fatal("expected parse error for malformed local config")
+	}
+}
+
+func TestLocalContext(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".coolify.json"), []byte(`{"context":"prod"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	name, path, err := LocalContext()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "prod" || path == "" {
+		t.Fatalf("got name=%q path=%q, want name=prod and a path", name, path)
+	}
+}


### PR DESCRIPTION
## Changes

Adds a repo-local config file so a repository can pin which context every `coolify` command inside it targets, without anyone having to remember `--context` or flip the global default back and forth.

`.coolify.json` (or `.coolifyrc`) at the repo root:

```json
{
  "context": "production"
}
```

The CLI walks up from the working directory and uses the nearest one.

Resolution order:

1. `--context` flag
2. repo-local `.coolify.json` / `.coolifyrc`
3. global default context

- **No credentials in the repo.** The file only names a context that already exists in `~/.config/coolify/config.json`; tokens stay global.
- Both file names are plain JSON, so no new dependency (`.coolify.toml` would need a TOML parser for a single key — happy to add it if you'd prefer that shape).
- A repo-local file naming a context that doesn't exist is a hard error that prints both paths, rather than a silent fallback to the default instance — silently deploying to the wrong place is the thing the issue is about. Malformed JSON errors too, for the same reason.
- `--debug` prints which file the context came from.
- Wired into `cli.GetAPIClient`, the single point where every command resolves its context, so all commands pick it up. No command surface changes.
- `internal/config/local.go` + `local_test.go`, docs in README.md, CLAUDE.md and ARCHITECTURE.md.

Testing: `internal/config/local_test.go` covers discovery from a nested directory, nearest-file-wins, absence, and parse failure. `go test -race ./internal/...` (config package at 83.3%), `gofmt -s`, and `go vet ./...` are green; also verified against a built binary for the flag-override, repo-local hit, and repo-local miss paths.

## Issues & Discussions

- fix #58 — [Support repo-local config for context selection](https://github.com/coollabsio/coolify-cli/issues/58)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
