### PR TITLE
chore: retarget CI and docs from v4.x to main

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          ref: v4.x
+          ref: main
           fetch-depth: 0
 
       - name: Update version file
@@ -49,7 +49,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add internal/version/checker.go
           git commit -m "chore: bump version to $TAG"
-          git push origin v4.x
+          git push origin main
 
           # Move the tag to point to the new commit with updated version
           git tag -d "$TAG" || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Testing CLI
 
 on:
   push:
-    branches: ["v4.x"]
+    branches: ["main"]
   pull_request:
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -575,10 +575,10 @@ feat: add server domains list command
 ### Pull Requests
 
 1. **Fork** the repository
-2. **Create a branch** from `v4.x`: `git checkout -b feature/my-feature v4.x`
+2. **Create a branch** from `main`: `git checkout -b feature/my-feature main`
 3. **Make your changes** with tests
 4. **Push** to your fork: `git push origin feature/my-feature`
-5. **Open a pull request** against the `v4.x` branch
+5. **Open a pull request** against the `main` branch
 6. **Describe your changes** clearly in the PR description
 7. **Link related issues** using "Fixes #123" or "Closes #123"
 

--- a/HOW-TO-RELEASE.md
+++ b/HOW-TO-RELEASE.md
@@ -5,7 +5,7 @@ This guide explains the release process for the Coolify CLI.
 ## Prerequisites
 
 - Write access to the `coollabsio/coolify-cli` repository
-- All changes merged to the target branch (`v4.x`)
+- All changes merged to the target branch (`main`)
 - All tests passing (`go test ./internal/...`)
 
 ## Release Process
@@ -15,7 +15,7 @@ This guide explains the release process for the Coolify CLI.
 1. Go to https://github.com/coollabsio/coolify-cli/releases/new
 2. Click "Choose a tag" and create a new tag:
    - **Tag name**: `v1.x.x` (must start with `v`, e.g., `v1.2.3`)
-   - **Target**: `v4.x` (or your target branch)
+   - **Target**: `main` (or your target branch)
 3. **Release title**: `v1.x.x` (same as tag name)
 4. **Description**: Write release notes describing:
    - New features
@@ -48,7 +48,7 @@ Once you publish the release:
 4. Binaries are automatically uploaded to the release
 5. A follow-up `update-version` job then:
    - Updates the `version` constant in `internal/version/checker.go` to the new tag
-   - Commits the bump to `v4.x` as `chore: bump version to vX.Y.Z`
+   - Commits the bump to `main` as `chore: bump version to vX.Y.Z`
    - Force-moves the release tag to point at that new commit
 6. GoReleaser also publishes a Homebrew formula to the tap at [`coollabsio/homebrew-coolify-cli`](https://github.com/coollabsio/homebrew-coolify-cli) (under `Formula/coolify-cli.rb`), using the `HOMEBREW_TAP_GITHUB_TOKEN` secret
 7. The release becomes available at:
@@ -62,8 +62,8 @@ Once you publish the release:
 After the workflow completes (usually 2-5 minutes), verify without touching your local install:
 
 1. Check the release page has all platform binaries (Linux/macOS/Windows × amd64/arm64)
-2. Confirm the `update-version` job committed the bump on `v4.x` (look for `chore: bump version to vX.Y.Z`) and that the tag now points at that commit
-3. Confirm `internal/version/checker.go` on `v4.x` has the new version
+2. Confirm the `update-version` job committed the bump on `main` (look for `chore: bump version to vX.Y.Z`) and that the tag now points at that commit
+3. Confirm `internal/version/checker.go` on `main` has the new version
 4. Confirm the Homebrew tap has a new `Formula/coolify-cli.rb` commit for this version at https://github.com/coollabsio/homebrew-coolify-cli
 
 ## Troubleshooting
@@ -76,7 +76,7 @@ After the workflow completes (usually 2-5 minutes), verify without touching your
   - GoReleaser configuration issues
 
 ### Version Not Updating
-- The version is injected at build time via ldflags into `internal/version.version` — you do **not** need to edit it manually before releasing. The post-release `update-version` job also rewrites `internal/version/checker.go` on `v4.x`.
+- The version is injected at build time via ldflags into `internal/version.version` — you do **not** need to edit it manually before releasing. The post-release `update-version` job also rewrites `internal/version/checker.go` on `main`.
 - If the hardcoded fallback in `internal/version/checker.go` is stale, check that the `update-version` job ran successfully after the release.
 - The tag must start with `v` (e.g., `v1.2.3`, not `1.2.3`)
 - Check that the workflow has write permissions (`contents: write` in `release-cli.yml`)
@@ -92,7 +92,7 @@ Before creating a release:
 
 - [ ] All tests pass: `go test ./internal/...`
 - [ ] Code is formatted: `go fmt ./...`
-- [ ] Changes merged to `v4.x` branch
+- [ ] Changes merged to `main` branch
 - [ ] Release notes prepared
 
 > Note: You do **not** need to bump the version manually. GoReleaser injects the tag version via ldflags, and the `update-version` CI job commits the bump to `internal/version/checker.go` after the release.
@@ -101,7 +101,7 @@ After creating a release:
 
 - [ ] GitHub Actions workflow completed successfully (both `release-cli` and `update-version` jobs)
 - [ ] All platform binaries are present on the release page
-- [ ] `internal/version/checker.go` on `v4.x` shows the new version
+- [ ] `internal/version/checker.go` on `main` shows the new version
 - [ ] Homebrew tap has a fresh `Formula/coolify-cli.rb` commit
 
 ## Configuration Files


### PR DESCRIPTION
## Changes

Retarget this repo's own branch references from `v4.x` to `main` so the default-branch rename can proceed.

- `.github/workflows/test.yml` — run on push to `main`
- `.github/workflows/release-cli.yml` — `update-version` checks out and pushes `main`
- `HOW-TO-RELEASE.md` / `CONTRIBUTING.md` — contributor and release docs

Coolify OpenAPI `v4.x` URLs are intentionally unchanged (other repo).

## Issues & Discussions

- Pre-step for renaming the default branch `v4.x` → `main`