### PR TITLE
fix(context): redact API tokens from list output

### DIFF
--- a/cmd/context/list.go
+++ b/cmd/context/list.go
@@ -4,9 +4,14 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/coollabsio/coolify-cli/internal/config"
 	"github.com/coollabsio/coolify-cli/internal/output"
 )
+
+type contextSummary struct {
+	Name    string `json:"name"`
+	FQDN    string `json:"fqdn"`
+	Default bool   `json:"default"`
+}
 
 // NewListCommand creates the list command
 func NewListCommand() *cobra.Command {
@@ -22,25 +27,21 @@ func NewListCommand() *cobra.Command {
 			instancesInterface := instancesRaw.([]interface{})
 
 			format, _ := cmd.Flags().GetString("format")
-			showSensitive, _ := cmd.Flags().GetBool("show-sensitive")
 
-			// Convert interface{} to config.Instance structs
-			var instances []config.Instance
+			// Use a credential-free view model so list output can never expose tokens.
+			var instances []contextSummary
 			for _, item := range instancesInterface {
 				itemMap := item.(map[string]any)
 
-				instance := config.Instance{
+				instance := contextSummary{
 					Name:    getString(itemMap, "name"),
 					FQDN:    getString(itemMap, "fqdn"),
-					Token:   getString(itemMap, "token"),
 					Default: getBool(itemMap, "default"),
 				}
 				instances = append(instances, instance)
 			}
 
-			formatter, err := output.NewFormatter(format, output.Options{
-				ShowSensitive: showSensitive,
-			})
+			formatter, err := output.NewFormatter(format, output.Options{})
 			if err != nil {
 				return err
 			}

--- a/cmd/context/list_test.go
+++ b/cmd/context/list_test.go
@@ -1,0 +1,96 @@
+package context
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sentinelToken = "sentinel-secret-token"
+
+func executeListCommand(t *testing.T, format string, showSensitive bool) string {
+	t.Helper()
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.Set("instances", []any{map[string]any{
+		"name":    "production",
+		"fqdn":    "https://coolify.example.com",
+		"token":   sentinelToken,
+		"default": true,
+	}, map[string]any{
+		"name":    "staging",
+		"fqdn":    "https://staging.example.com",
+		"token":   sentinelToken,
+		"default": false,
+	}})
+
+	root := &cobra.Command{Use: "test"}
+	root.PersistentFlags().String("format", "table", "")
+	root.PersistentFlags().Bool("show-sensitive", false, "")
+	root.AddCommand(NewListCommand())
+	root.SetArgs([]string{"list", "--format", format})
+	if showSensitive {
+		root.SetArgs([]string{"list", "--format", format, "--show-sensitive"})
+	}
+
+	read, write, err := os.Pipe()
+	require.NoError(t, err)
+	originalStdout := os.Stdout
+	os.Stdout = write
+	t.Cleanup(func() { os.Stdout = originalStdout })
+
+	var output bytes.Buffer
+	require.NoError(t, root.Execute())
+	require.NoError(t, write.Close())
+	os.Stdout = originalStdout
+	_, err = io.Copy(&output, read)
+	require.NoError(t, err)
+	require.NoError(t, read.Close())
+	return output.String()
+}
+
+func TestListCommand_NeverExposesTokens(t *testing.T) {
+	for _, format := range []string{"table", "json", "pretty"} {
+		for _, showSensitive := range []bool{false, true} {
+			name := format
+			if showSensitive {
+				name += " with show-sensitive"
+			}
+			t.Run(name, func(t *testing.T) {
+				output := executeListCommand(t, format, showSensitive)
+				assert.NotContains(t, output, sentinelToken)
+				assert.NotContains(t, strings.ToLower(output), "token")
+			})
+		}
+	}
+}
+
+func TestListCommand_StructuredFormatsContainOnlySafeContextMetadata(t *testing.T) {
+	for _, format := range []string{"json", "pretty"} {
+		t.Run(format, func(t *testing.T) {
+			output := executeListCommand(t, format, false)
+
+			var contexts []map[string]any
+			require.NoError(t, json.Unmarshal([]byte(output), &contexts))
+			require.Len(t, contexts, 2)
+			assert.Equal(t, map[string]any{
+				"name":    "production",
+				"fqdn":    "https://coolify.example.com",
+				"default": true,
+			}, contexts[0])
+			assert.Equal(t, map[string]any{
+				"name":    "staging",
+				"fqdn":    "https://staging.example.com",
+				"default": false,
+			}, contexts[1])
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Remove API tokens from context list output in table, JSON, and pretty formats.
- Keep tokens hidden even when `--show-sensitive` is provided.
- Add regression coverage ensuring only safe context metadata is returned.
- fixes #86

## Breaking Changes

- Structured context list output no longer includes the `token` field.

---

Fixes #86