### PR TITLE
fix(database): handle numeric backup retention storage values

### DIFF
--- a/cmd/database/backup/create.go
+++ b/cmd/database/backup/create.go
@@ -34,65 +34,7 @@ Example: coolify database backup create abc123 --frequency "0 0 * * *" --enabled
 				return err
 			}
 
-			req := &models.DatabaseBackupCreateRequest{}
-
-			// Apply flags if provided
-			if cmd.Flags().Changed("frequency") {
-				frequency, _ := cmd.Flags().GetString("frequency")
-				req.Frequency = &frequency
-			}
-			if cmd.Flags().Changed("enabled") {
-				enabled, _ := cmd.Flags().GetBool("enabled")
-				req.Enabled = &enabled
-			}
-			if cmd.Flags().Changed("save-s3") {
-				saveS3, _ := cmd.Flags().GetBool("save-s3")
-				req.SaveS3 = &saveS3
-			}
-			if cmd.Flags().Changed("s3-storage-uuid") {
-				s3UUID, _ := cmd.Flags().GetString("s3-storage-uuid")
-				req.S3StorageUUID = &s3UUID
-			}
-			if cmd.Flags().Changed("databases") {
-				databases, _ := cmd.Flags().GetString("databases")
-				req.DatabasesToBackup = &databases
-			}
-			if cmd.Flags().Changed("dump-all") {
-				dumpAll, _ := cmd.Flags().GetBool("dump-all")
-				req.DumpAll = &dumpAll
-			}
-			if cmd.Flags().Changed("retention-amount-locally") {
-				amount, _ := cmd.Flags().GetInt("retention-amount-locally")
-				req.DatabaseBackupRetentionAmountLocally = &amount
-			}
-			if cmd.Flags().Changed("retention-days-locally") {
-				days, _ := cmd.Flags().GetInt("retention-days-locally")
-				req.DatabaseBackupRetentionDaysLocally = &days
-			}
-			if cmd.Flags().Changed("retention-storage-locally") {
-				storage, _ := cmd.Flags().GetString("retention-storage-locally")
-				req.DatabaseBackupRetentionMaxStorageLocally = &storage
-			}
-			if cmd.Flags().Changed("retention-amount-s3") {
-				amount, _ := cmd.Flags().GetInt("retention-amount-s3")
-				req.DatabaseBackupRetentionAmountS3 = &amount
-			}
-			if cmd.Flags().Changed("retention-days-s3") {
-				days, _ := cmd.Flags().GetInt("retention-days-s3")
-				req.DatabaseBackupRetentionDaysS3 = &days
-			}
-			if cmd.Flags().Changed("retention-storage-s3") {
-				storage, _ := cmd.Flags().GetString("retention-storage-s3")
-				req.DatabaseBackupRetentionMaxStorageS3 = &storage
-			}
-			if cmd.Flags().Changed("timeout") {
-				timeout, _ := cmd.Flags().GetInt("timeout")
-				req.Timeout = &timeout
-			}
-			if cmd.Flags().Changed("disable-local") {
-				disableLocal, _ := cmd.Flags().GetBool("disable-local")
-				req.DisableLocalBackup = &disableLocal
-			}
+			req := buildCreateBackupRequest(cmd)
 
 			dbService := service.NewDatabaseService(client)
 			backup, err := dbService.CreateBackup(ctx, dbUUID, req)
@@ -118,12 +60,73 @@ Example: coolify database backup create abc123 --frequency "0 0 * * *" --enabled
 	createBackupCmd.Flags().Bool("dump-all", false, "Dump all databases")
 	createBackupCmd.Flags().Int("retention-amount-locally", 0, "Number of backups to retain locally")
 	createBackupCmd.Flags().Int("retention-days-locally", 0, "Days to retain backups locally")
-	createBackupCmd.Flags().String("retention-max-storage-locally", "", "Max storage for local backups (e.g., '1GB', '500MB')")
+	createBackupCmd.Flags().Float64("retention-max-storage-locally", 0, "Max storage for local backups (GB)")
 	createBackupCmd.Flags().Int("retention-amount-s3", 0, "Number of backups to retain in S3")
 	createBackupCmd.Flags().Int("retention-days-s3", 0, "Days to retain backups in S3")
-	createBackupCmd.Flags().String("retention-max-storage-s3", "", "Max storage for S3 backups (e.g., '1GB', '500MB')")
+	createBackupCmd.Flags().Float64("retention-max-storage-s3", 0, "Max storage for S3 backups (GB)")
 	createBackupCmd.Flags().Int("timeout", 0, "Backup timeout in seconds")
 	createBackupCmd.Flags().Bool("disable-local-backup", false, "Disable local backup storage")
 
 	return createBackupCmd
+}
+
+func buildCreateBackupRequest(cmd *cobra.Command) *models.DatabaseBackupCreateRequest {
+	req := &models.DatabaseBackupCreateRequest{}
+	if cmd.Flags().Changed("frequency") {
+		v, _ := cmd.Flags().GetString("frequency")
+		req.Frequency = &v
+	}
+	if cmd.Flags().Changed("enabled") {
+		v, _ := cmd.Flags().GetBool("enabled")
+		req.Enabled = &v
+	}
+	if cmd.Flags().Changed("save-s3") {
+		v, _ := cmd.Flags().GetBool("save-s3")
+		req.SaveS3 = &v
+	}
+	if cmd.Flags().Changed("s3-storage-uuid") {
+		v, _ := cmd.Flags().GetString("s3-storage-uuid")
+		req.S3StorageUUID = &v
+	}
+	if cmd.Flags().Changed("databases-to-backup") {
+		v, _ := cmd.Flags().GetString("databases-to-backup")
+		req.DatabasesToBackup = &v
+	}
+	if cmd.Flags().Changed("dump-all") {
+		v, _ := cmd.Flags().GetBool("dump-all")
+		req.DumpAll = &v
+	}
+	if cmd.Flags().Changed("retention-amount-locally") {
+		v, _ := cmd.Flags().GetInt("retention-amount-locally")
+		req.DatabaseBackupRetentionAmountLocally = &v
+	}
+	if cmd.Flags().Changed("retention-days-locally") {
+		v, _ := cmd.Flags().GetInt("retention-days-locally")
+		req.DatabaseBackupRetentionDaysLocally = &v
+	}
+	if cmd.Flags().Changed("retention-max-storage-locally") {
+		v, _ := cmd.Flags().GetFloat64("retention-max-storage-locally")
+		req.DatabaseBackupRetentionMaxStorageLocally = &v
+	}
+	if cmd.Flags().Changed("retention-amount-s3") {
+		v, _ := cmd.Flags().GetInt("retention-amount-s3")
+		req.DatabaseBackupRetentionAmountS3 = &v
+	}
+	if cmd.Flags().Changed("retention-days-s3") {
+		v, _ := cmd.Flags().GetInt("retention-days-s3")
+		req.DatabaseBackupRetentionDaysS3 = &v
+	}
+	if cmd.Flags().Changed("retention-max-storage-s3") {
+		v, _ := cmd.Flags().GetFloat64("retention-max-storage-s3")
+		req.DatabaseBackupRetentionMaxStorageS3 = &v
+	}
+	if cmd.Flags().Changed("timeout") {
+		v, _ := cmd.Flags().GetInt("timeout")
+		req.Timeout = &v
+	}
+	if cmd.Flags().Changed("disable-local-backup") {
+		v, _ := cmd.Flags().GetBool("disable-local-backup")
+		req.DisableLocalBackup = &v
+	}
+	return req
 }

--- a/cmd/database/backup/request_test.go
+++ b/cmd/database/backup/request_test.go
@@ -1,0 +1,57 @@
+package backup
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCreateBackupRequestUsesRegisteredFlags(t *testing.T) {
+	cmd := NewCreateCommand()
+	require.NoError(t, cmd.Flags().Set("databases-to-backup", "appdb"))
+	require.NoError(t, cmd.Flags().Set("retention-max-storage-locally", "2.5"))
+	require.NoError(t, cmd.Flags().Set("retention-max-storage-s3", "3.5"))
+	require.NoError(t, cmd.Flags().Set("disable-local-backup", "true"))
+
+	req := buildCreateBackupRequest(cmd)
+
+	require.NotNil(t, req.DatabasesToBackup)
+	assert.Equal(t, "appdb", *req.DatabasesToBackup)
+	require.NotNil(t, req.DatabaseBackupRetentionMaxStorageLocally)
+	assert.Equal(t, 2.5, *req.DatabaseBackupRetentionMaxStorageLocally)
+	require.NotNil(t, req.DatabaseBackupRetentionMaxStorageS3)
+	assert.Equal(t, 3.5, *req.DatabaseBackupRetentionMaxStorageS3)
+	require.NotNil(t, req.DisableLocalBackup)
+	assert.True(t, *req.DisableLocalBackup)
+
+	payload, err := json.Marshal(req)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"databases_to_backup":"appdb",
+		"database_backup_retention_max_storage_locally":2.5,
+		"database_backup_retention_max_storage_s3":3.5,
+		"disable_local_backup":true
+	}`, string(payload))
+}
+
+func TestBuildUpdateBackupRequestAcceptsDecimalStorage(t *testing.T) {
+	cmd := NewUpdateCommand()
+	require.NoError(t, cmd.Flags().Set("retention-max-storage-locally", "4.5"))
+	require.NoError(t, cmd.Flags().Set("retention-max-storage-s3", "5.5"))
+
+	req, hasChanges := buildUpdateBackupRequest(cmd)
+
+	assert.True(t, hasChanges)
+	require.NotNil(t, req.DatabaseBackupRetentionMaxStorageLocally)
+	assert.Equal(t, 4.5, *req.DatabaseBackupRetentionMaxStorageLocally)
+	require.NotNil(t, req.DatabaseBackupRetentionMaxStorageS3)
+	assert.Equal(t, 5.5, *req.DatabaseBackupRetentionMaxStorageS3)
+}
+
+func TestBuildUpdateBackupRequestReportsNoChanges(t *testing.T) {
+	_, hasChanges := buildUpdateBackupRequest(NewUpdateCommand())
+
+	assert.False(t, hasChanges)
+}

--- a/cmd/database/backup/update.go
+++ b/cmd/database/backup/update.go
@@ -22,71 +22,7 @@ func NewUpdateCommand() *cobra.Command {
 			dbUUID := args[0]
 			backupUUID := args[1]
 
-			req := &models.DatabaseBackupUpdateRequest{}
-			hasChanges := false
-
-			if cmd.Flags().Changed("enabled") {
-				enabled, _ := cmd.Flags().GetBool("enabled")
-				req.Enabled = &enabled
-				hasChanges = true
-			}
-			if cmd.Flags().Changed("frequency") {
-				freq, _ := cmd.Flags().GetString("frequency")
-				req.Frequency = &freq
-				hasChanges = true
-			}
-			if cmd.Flags().Changed("save-s3") {
-				saveS3, _ := cmd.Flags().GetBool("save-s3")
-				req.SaveS3 = &saveS3
-				hasChanges = true
-			}
-			if cmd.Flags().Changed("s3-storage-uuid") {
-				s3UUID, _ := cmd.Flags().GetString("s3-storage-uuid")
-				req.S3StorageUUID = &s3UUID
-				hasChanges = true
-			}
-			if cmd.Flags().Changed("databases-to-backup") {
-				dbs, _ := cmd.Flags().GetString("databases-to-backup")
-				req.DatabasesToBackup = &dbs
-				hasChanges = true
-			}
-			if cmd.Flags().Changed("dump-all") {
-				dumpAll, _ := cmd.Flags().GetBool("dump-all")
-				req.DumpAll = &dumpAll
-				hasChanges = true
-			}
-
-			// Retention settings
-			if cmd.Flags().Changed("retention-amount-locally") {
-				amount, _ := cmd.Flags().GetInt("retention-amount-locally")
-				req.DatabaseBackupRetentionAmountLocally = &amount
-				hasChanges = true
-			}
-			if cmd.Flags().Changed("retention-days-locally") {
-				days, _ := cmd.Flags().GetInt("retention-days-locally")
-				req.DatabaseBackupRetentionDaysLocally = &days
-				hasChanges = true
-			}
-			if cmd.Flags().Changed("retention-max-storage-locally") {
-				storage, _ := cmd.Flags().GetInt("retention-max-storage-locally")
-				req.DatabaseBackupRetentionMaxStorageLocally = &storage
-				hasChanges = true
-			}
-			if cmd.Flags().Changed("retention-amount-s3") {
-				amount, _ := cmd.Flags().GetInt("retention-amount-s3")
-				req.DatabaseBackupRetentionAmountS3 = &amount
-				hasChanges = true
-			}
-			if cmd.Flags().Changed("retention-days-s3") {
-				days, _ := cmd.Flags().GetInt("retention-days-s3")
-				req.DatabaseBackupRetentionDaysS3 = &days
-				hasChanges = true
-			}
-			if cmd.Flags().Changed("retention-max-storage-s3") {
-				storage, _ := cmd.Flags().GetInt("retention-max-storage-s3")
-				req.DatabaseBackupRetentionMaxStorageS3 = &storage
-				hasChanges = true
-			}
+			req, hasChanges := buildUpdateBackupRequest(cmd)
 
 			if !hasChanges {
 				return fmt.Errorf("no fields to update")
@@ -116,10 +52,74 @@ func NewUpdateCommand() *cobra.Command {
 	updateBackupCmd.Flags().Bool("dump-all", false, "Dump all databases")
 	updateBackupCmd.Flags().Int("retention-amount-locally", 0, "Number of backups to retain locally")
 	updateBackupCmd.Flags().Int("retention-days-locally", 0, "Days to retain backups locally")
-	updateBackupCmd.Flags().Int("retention-max-storage-locally", 0, "Max storage for local backups (MB)")
+	updateBackupCmd.Flags().Float64("retention-max-storage-locally", 0, "Max storage for local backups (GB)")
 	updateBackupCmd.Flags().Int("retention-amount-s3", 0, "Number of backups to retain in S3")
 	updateBackupCmd.Flags().Int("retention-days-s3", 0, "Days to retain backups in S3")
-	updateBackupCmd.Flags().Int("retention-max-storage-s3", 0, "Max storage for S3 backups (MB)")
+	updateBackupCmd.Flags().Float64("retention-max-storage-s3", 0, "Max storage for S3 backups (GB)")
 
 	return updateBackupCmd
+}
+
+func buildUpdateBackupRequest(cmd *cobra.Command) (*models.DatabaseBackupUpdateRequest, bool) {
+	req := &models.DatabaseBackupUpdateRequest{}
+	hasChanges := false
+	for _, name := range []string{
+		"enabled", "frequency", "save-s3", "s3-storage-uuid", "databases-to-backup", "dump-all",
+		"retention-amount-locally", "retention-days-locally", "retention-max-storage-locally",
+		"retention-amount-s3", "retention-days-s3", "retention-max-storage-s3",
+	} {
+		if cmd.Flags().Changed(name) {
+			hasChanges = true
+			break
+		}
+	}
+	if cmd.Flags().Changed("enabled") {
+		v, _ := cmd.Flags().GetBool("enabled")
+		req.Enabled = &v
+	}
+	if cmd.Flags().Changed("frequency") {
+		v, _ := cmd.Flags().GetString("frequency")
+		req.Frequency = &v
+	}
+	if cmd.Flags().Changed("save-s3") {
+		v, _ := cmd.Flags().GetBool("save-s3")
+		req.SaveS3 = &v
+	}
+	if cmd.Flags().Changed("s3-storage-uuid") {
+		v, _ := cmd.Flags().GetString("s3-storage-uuid")
+		req.S3StorageUUID = &v
+	}
+	if cmd.Flags().Changed("databases-to-backup") {
+		v, _ := cmd.Flags().GetString("databases-to-backup")
+		req.DatabasesToBackup = &v
+	}
+	if cmd.Flags().Changed("dump-all") {
+		v, _ := cmd.Flags().GetBool("dump-all")
+		req.DumpAll = &v
+	}
+	if cmd.Flags().Changed("retention-amount-locally") {
+		v, _ := cmd.Flags().GetInt("retention-amount-locally")
+		req.DatabaseBackupRetentionAmountLocally = &v
+	}
+	if cmd.Flags().Changed("retention-days-locally") {
+		v, _ := cmd.Flags().GetInt("retention-days-locally")
+		req.DatabaseBackupRetentionDaysLocally = &v
+	}
+	if cmd.Flags().Changed("retention-max-storage-locally") {
+		v, _ := cmd.Flags().GetFloat64("retention-max-storage-locally")
+		req.DatabaseBackupRetentionMaxStorageLocally = &v
+	}
+	if cmd.Flags().Changed("retention-amount-s3") {
+		v, _ := cmd.Flags().GetInt("retention-amount-s3")
+		req.DatabaseBackupRetentionAmountS3 = &v
+	}
+	if cmd.Flags().Changed("retention-days-s3") {
+		v, _ := cmd.Flags().GetInt("retention-days-s3")
+		req.DatabaseBackupRetentionDaysS3 = &v
+	}
+	if cmd.Flags().Changed("retention-max-storage-s3") {
+		v, _ := cmd.Flags().GetFloat64("retention-max-storage-s3")
+		req.DatabaseBackupRetentionMaxStorageS3 = &v
+	}
+	return req, hasChanges
 }

--- a/internal/models/database.go
+++ b/internal/models/database.go
@@ -226,63 +226,63 @@ type DatabaseEnvBulkUpdateResponse []DatabaseEnvironmentVariable
 
 // DatabaseBackup represents a scheduled database backup configuration
 type DatabaseBackup struct {
-	ID                                       int     `json:"-" table:"-"`
-	UUID                                     string  `json:"uuid"`
-	Description                              *string `json:"description,omitempty"`
-	Enabled                                  *bool   `json:"enabled,omitempty"`
-	Frequency                                *string `json:"frequency,omitempty"`
-	SaveS3                                   *bool   `json:"save_s3,omitempty"`
-	S3StorageID                              *int    `json:"-" table:"-"`
-	DatabasesToBackup                        *string `json:"databases_to_backup,omitempty"`
-	DumpAll                                  *bool   `json:"dump_all,omitempty"`
-	DatabaseBackupRetentionAmountLocally     *int    `json:"database_backup_retention_amount_locally,omitempty"`
-	DatabaseBackupRetentionDaysLocally       *int    `json:"database_backup_retention_days_locally,omitempty"`
-	DatabaseBackupRetentionMaxStorageLocally *string `json:"database_backup_retention_max_storage_locally,omitempty"`
-	DatabaseBackupRetentionAmountS3          *int    `json:"database_backup_retention_amount_s3,omitempty"`
-	DatabaseBackupRetentionDaysS3            *int    `json:"database_backup_retention_days_s3,omitempty"`
-	DatabaseBackupRetentionMaxStorageS3      *string `json:"database_backup_retention_max_storage_s3,omitempty"`
-	DatabaseType                             *string `json:"database_type,omitempty" table:"-"`
-	DatabaseID                               *int    `json:"-" table:"-"`
-	TeamID                                   *int    `json:"-" table:"-"`
-	Timeout                                  *int    `json:"timeout,omitempty"`
-	DisableLocalBackup                       *bool   `json:"disable_local_backup,omitempty"`
-	CreatedAt                                string  `json:"-" table:"-"`
-	UpdatedAt                                string  `json:"-" table:"-"`
+	ID                                       int      `json:"-" table:"-"`
+	UUID                                     string   `json:"uuid"`
+	Description                              *string  `json:"description,omitempty"`
+	Enabled                                  *bool    `json:"enabled,omitempty"`
+	Frequency                                *string  `json:"frequency,omitempty"`
+	SaveS3                                   *bool    `json:"save_s3,omitempty"`
+	S3StorageID                              *int     `json:"-" table:"-"`
+	DatabasesToBackup                        *string  `json:"databases_to_backup,omitempty"`
+	DumpAll                                  *bool    `json:"dump_all,omitempty"`
+	DatabaseBackupRetentionAmountLocally     *int     `json:"database_backup_retention_amount_locally,omitempty"`
+	DatabaseBackupRetentionDaysLocally       *int     `json:"database_backup_retention_days_locally,omitempty"`
+	DatabaseBackupRetentionMaxStorageLocally *float64 `json:"database_backup_retention_max_storage_locally,omitempty"`
+	DatabaseBackupRetentionAmountS3          *int     `json:"database_backup_retention_amount_s3,omitempty"`
+	DatabaseBackupRetentionDaysS3            *int     `json:"database_backup_retention_days_s3,omitempty"`
+	DatabaseBackupRetentionMaxStorageS3      *float64 `json:"database_backup_retention_max_storage_s3,omitempty"`
+	DatabaseType                             *string  `json:"database_type,omitempty" table:"-"`
+	DatabaseID                               *int     `json:"-" table:"-"`
+	TeamID                                   *int     `json:"-" table:"-"`
+	Timeout                                  *int     `json:"timeout,omitempty"`
+	DisableLocalBackup                       *bool    `json:"disable_local_backup,omitempty"`
+	CreatedAt                                string   `json:"-" table:"-"`
+	UpdatedAt                                string   `json:"-" table:"-"`
 }
 
 // DatabaseBackupCreateRequest represents the request to create a backup configuration
 type DatabaseBackupCreateRequest struct {
-	Frequency                                *string `json:"frequency,omitempty"`
-	Enabled                                  *bool   `json:"enabled,omitempty"`
-	SaveS3                                   *bool   `json:"save_s3,omitempty"`
-	S3StorageUUID                            *string `json:"s3_storage_uuid,omitempty"`
-	DatabasesToBackup                        *string `json:"databases_to_backup,omitempty"`
-	DumpAll                                  *bool   `json:"dump_all,omitempty"`
-	DatabaseBackupRetentionAmountLocally     *int    `json:"database_backup_retention_amount_locally,omitempty"`
-	DatabaseBackupRetentionDaysLocally       *int    `json:"database_backup_retention_days_locally,omitempty"`
-	DatabaseBackupRetentionMaxStorageLocally *string `json:"database_backup_retention_max_storage_locally,omitempty"`
-	DatabaseBackupRetentionAmountS3          *int    `json:"database_backup_retention_amount_s3,omitempty"`
-	DatabaseBackupRetentionDaysS3            *int    `json:"database_backup_retention_days_s3,omitempty"`
-	DatabaseBackupRetentionMaxStorageS3      *string `json:"database_backup_retention_max_storage_s3,omitempty"`
-	Timeout                                  *int    `json:"timeout,omitempty"`
-	DisableLocalBackup                       *bool   `json:"disable_local_backup,omitempty"`
+	Frequency                                *string  `json:"frequency,omitempty"`
+	Enabled                                  *bool    `json:"enabled,omitempty"`
+	SaveS3                                   *bool    `json:"save_s3,omitempty"`
+	S3StorageUUID                            *string  `json:"s3_storage_uuid,omitempty"`
+	DatabasesToBackup                        *string  `json:"databases_to_backup,omitempty"`
+	DumpAll                                  *bool    `json:"dump_all,omitempty"`
+	DatabaseBackupRetentionAmountLocally     *int     `json:"database_backup_retention_amount_locally,omitempty"`
+	DatabaseBackupRetentionDaysLocally       *int     `json:"database_backup_retention_days_locally,omitempty"`
+	DatabaseBackupRetentionMaxStorageLocally *float64 `json:"database_backup_retention_max_storage_locally,omitempty"`
+	DatabaseBackupRetentionAmountS3          *int     `json:"database_backup_retention_amount_s3,omitempty"`
+	DatabaseBackupRetentionDaysS3            *int     `json:"database_backup_retention_days_s3,omitempty"`
+	DatabaseBackupRetentionMaxStorageS3      *float64 `json:"database_backup_retention_max_storage_s3,omitempty"`
+	Timeout                                  *int     `json:"timeout,omitempty"`
+	DisableLocalBackup                       *bool    `json:"disable_local_backup,omitempty"`
 }
 
 // DatabaseBackupUpdateRequest represents the request to update a backup configuration
 type DatabaseBackupUpdateRequest struct {
-	SaveS3                                   *bool   `json:"save_s3,omitempty"`
-	S3StorageUUID                            *string `json:"s3_storage_uuid,omitempty"`
-	BackupNow                                *bool   `json:"backup_now,omitempty"`
-	Enabled                                  *bool   `json:"enabled,omitempty"`
-	DatabasesToBackup                        *string `json:"databases_to_backup,omitempty"`
-	DumpAll                                  *bool   `json:"dump_all,omitempty"`
-	Frequency                                *string `json:"frequency,omitempty"`
-	DatabaseBackupRetentionAmountLocally     *int    `json:"database_backup_retention_amount_locally,omitempty"`
-	DatabaseBackupRetentionDaysLocally       *int    `json:"database_backup_retention_days_locally,omitempty"`
-	DatabaseBackupRetentionMaxStorageLocally *int    `json:"database_backup_retention_max_storage_locally,omitempty"`
-	DatabaseBackupRetentionAmountS3          *int    `json:"database_backup_retention_amount_s3,omitempty"`
-	DatabaseBackupRetentionDaysS3            *int    `json:"database_backup_retention_days_s3,omitempty"`
-	DatabaseBackupRetentionMaxStorageS3      *int    `json:"database_backup_retention_max_storage_s3,omitempty"`
+	SaveS3                                   *bool    `json:"save_s3,omitempty"`
+	S3StorageUUID                            *string  `json:"s3_storage_uuid,omitempty"`
+	BackupNow                                *bool    `json:"backup_now,omitempty"`
+	Enabled                                  *bool    `json:"enabled,omitempty"`
+	DatabasesToBackup                        *string  `json:"databases_to_backup,omitempty"`
+	DumpAll                                  *bool    `json:"dump_all,omitempty"`
+	Frequency                                *string  `json:"frequency,omitempty"`
+	DatabaseBackupRetentionAmountLocally     *int     `json:"database_backup_retention_amount_locally,omitempty"`
+	DatabaseBackupRetentionDaysLocally       *int     `json:"database_backup_retention_days_locally,omitempty"`
+	DatabaseBackupRetentionMaxStorageLocally *float64 `json:"database_backup_retention_max_storage_locally,omitempty"`
+	DatabaseBackupRetentionAmountS3          *int     `json:"database_backup_retention_amount_s3,omitempty"`
+	DatabaseBackupRetentionDaysS3            *int     `json:"database_backup_retention_days_s3,omitempty"`
+	DatabaseBackupRetentionMaxStorageS3      *float64 `json:"database_backup_retention_max_storage_s3,omitempty"`
 }
 
 // DatabaseBackupExecution represents a single backup execution

--- a/internal/service/database_test.go
+++ b/internal/service/database_test.go
@@ -554,6 +554,8 @@ func TestDatabaseService_ListBackups(t *testing.T) {
 		statusCode     int
 		wantErr        bool
 		wantCount      int
+		wantLocalMax   float64
+		wantS3Max      float64
 	}{
 		{
 			name:   "successful list",
@@ -563,13 +565,17 @@ func TestDatabaseService_ListBackups(t *testing.T) {
 					"uuid": "backup-uuid-1",
 					"enabled": true,
 					"frequency": "0 2 * * *",
+					"database_backup_retention_max_storage_locally": 10,
+					"database_backup_retention_max_storage_s3": 2.5,
 					"created_at": "2024-01-01T00:00:00Z",
 					"updated_at": "2024-01-01T00:00:00Z"
 				}
 			]`,
-			statusCode: http.StatusOK,
-			wantErr:    false,
-			wantCount:  1,
+			statusCode:   http.StatusOK,
+			wantErr:      false,
+			wantCount:    1,
+			wantLocalMax: 10,
+			wantS3Max:    2.5,
 		},
 		{
 			name:           "empty list",
@@ -610,6 +616,12 @@ func TestDatabaseService_ListBackups(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Len(t, backups, tt.wantCount)
+			if tt.wantCount > 0 {
+				require.NotNil(t, backups[0].DatabaseBackupRetentionMaxStorageLocally)
+				require.NotNil(t, backups[0].DatabaseBackupRetentionMaxStorageS3)
+				assert.Equal(t, tt.wantLocalMax, *backups[0].DatabaseBackupRetentionMaxStorageLocally)
+				assert.Equal(t, tt.wantS3Max, *backups[0].DatabaseBackupRetentionMaxStorageS3)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Decode local and S3 backup retention storage limits as numeric GB values, including decimals.
- Align create and update flags with the API and ensure requests serialize storage limits as numbers.
- Add coverage for listing backups and building create/update requests with decimal limits.
- Fixes #82.

## Breaking Changes

- `--retention-max-storage-locally` and `--retention-max-storage-s3` now require numeric GB values instead of unit-suffixed strings or MB values.

---

Fixes #82